### PR TITLE
[BugFix] DreamBooth Dataset

### DIFF
--- a/diffengine/datasets/hf_dreambooth_datasets.py
+++ b/diffengine/datasets/hf_dreambooth_datasets.py
@@ -147,6 +147,9 @@ class HFDreamBoothDataset(Dataset):
             class_image = Image.open(class_image)
             result_class_image = dict(img=class_image, text=self.class_prompt)
             result_class_image = self.pipeline(result_class_image)
-            result['result_class_image'] = result_class_image
+            assert 'inputs' in result
+            assert 'inputs' in result_class_image
+            result['inputs']['result_class_image'] = result_class_image[
+                'inputs']
 
         return result


### PR DESCRIPTION
# Bug

DreamBooth Dataset should support `PackInputs` output format.

```
Traceback (most recent call last):
  File "/home/ubuntu/.local/lib/python3.8/site-packages/diffengine/.mim/tools/train.py", line 103, in <module>
    main()
  File "/home/ubuntu/.local/lib/python3.8/site-packages/diffengine/.mim/tools/train.py", line 99, in main
    runner.train()
  File "/home/ubuntu/.local/lib/python3.8/site-packages/mmengine/runner/runner.py", line 1735, in train
    model = self.train_loop.run()  # type: ignore
  File "/home/ubuntu/.local/lib/python3.8/site-packages/mmengine/runner/loops.py", line 277, in run
    data_batch = next(self.dataloader_iterator)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/mmengine/runner/loops.py", line 164, in __next__
    data = next(self._iterator)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 633, in __next__
    data = self._next_data()
  File "/home/ubuntu/.local/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 1345, in _next_data
    return self._process_data(data)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 1371, in _process_data
    data.reraise()
  File "/home/ubuntu/.local/lib/python3.8/site-packages/torch/_utils.py", line 644, in reraise
    raise exception
KeyError: Caught KeyError in DataLoader worker process 0.
Original Traceback (most recent call last):
  File "/home/ubuntu/.local/lib/python3.8/site-packages/torch/utils/data/_utils/worker.py", line 308, in _worker_loop
    data = fetcher.fetch(index)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 51, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/home/ubuntu/.local/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 51, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/home/ubuntu/.local/lib/python3.8/site-packages/diffengine/datasets/hf_dreambooth_datasets.py", line 152, in __getitem__
    result['inputs']['result_class_image'] = result_class_image['inputs']
KeyError: 'inputs'
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
