### PR TITLE
[Enhance] Add training time for distill sd

### DIFF
--- a/configs/distill_sd_dreambooth/README.md
+++ b/configs/distill_sd_dreambooth/README.md
@@ -79,6 +79,8 @@ $ mim run diffengine demo_lora "A photo of sks dog in a bucket" work_dirs/small_
 
 ![example1](https://github.com/okotaku/diffengine/assets/24734142/16cc3ef2-860d-4e4a-8b1d-8f56d9021db9)
 
+We uploaded pretrained checkpoint on [`takuoko/small-sd-dreambooth-lora-dog`](https://huggingface.co/takuoko/small-sd-dreambooth-lora-dog).
+
 #### tiny_sd_dreambooth_lora_dog
 
 ![example2](https://github.com/okotaku/diffengine/assets/24734142/2d7f3f20-fff4-41f1-9b17-be7b19129769)

--- a/configs/distill_sd_dreambooth/README.md
+++ b/configs/distill_sd_dreambooth/README.md
@@ -26,6 +26,24 @@ $ mim train diffengine ${CONFIG_FILE} --gpus 2 --launcher pytorch
 $ mim train diffengine configs/distill_sd_dreambooth/small_sd_dreambooth_lora_dog.py
 ```
 
+## Training Speed
+
+Environment:
+
+- A6000 Single GPU
+- nvcr.io/nvidia/pytorch:23.07-py3
+
+Settings:
+
+- 1k iterations training, (validation 4 images / 100 iterations)
+- LoRA (rank=8) / DreamBooth
+
+|  Model   | total time |
+| :------: | :--------: |
+|  SDV1.5  | 16 m 39 s  |
+| Small SD | 11 m 57 s  |
+| Tiny SD  | 11 m 17 s  |
+
 ## Inference with diffusers
 
 Once you have trained a model, specify the path to where the model is saved, and use it for inference with the `diffusers`.


### PR DESCRIPTION
## Results (Optional)

#### Training Speed

Environment:

- A6000 Single GPU
- nvcr.io/nvidia/pytorch:23.07-py3

Settings:

- 1k iterations training, (validation 4 images / 100 iterations)
- LoRA (rank=8) / DreamBooth

|  Model   | total time |
| :------: | :--------: |
|  SDV1.5  | 16 m 39 s  |
| Small SD | 11 m 57 s  |
| Tiny SD  | 11 m 17 s  |

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
