### PR TITLE
[Feature] Human face DreamBooth with Distill SD.

### DIFF
--- a/configs/_base_/datasets/keramer_face_dreambooth.py
+++ b/configs/_base_/datasets/keramer_face_dreambooth.py
@@ -1,0 +1,34 @@
+train_pipeline = [
+    dict(type='torchvision/Resize', size=512, interpolation='bilinear'),
+    dict(type='RandomCrop', size=512),
+    dict(type='RandomHorizontalFlip', p=0.5),
+    dict(type='torchvision/ToTensor'),
+    dict(type='torchvision/Normalize', mean=[0.5], std=[0.5]),
+    dict(type='PackInputs'),
+]
+train_dataloader = dict(
+    batch_size=4,
+    num_workers=4,
+    dataset=dict(
+        type='HFDreamBoothDataset',
+        dataset='diffusers/keramer-face-example',
+        instance_prompt='a photo of sks person',
+        pipeline=train_pipeline,
+        class_prompt='a photo of person'),
+    sampler=dict(type='InfiniteSampler', shuffle=True),
+)
+
+val_dataloader = None
+val_evaluator = None
+test_dataloader = val_dataloader
+test_evaluator = val_evaluator
+
+custom_hooks = [
+    dict(
+        type='VisualizationHook',
+        prompt=['a photo of sks person in suits'] * 4,
+        by_epoch=False,
+        interval=100),
+    dict(type='LoRASaveHook'),
+    dict(type='UnetEMAHook', momentum=1e-4, priority='ABOVE_NORMAL')
+]

--- a/configs/distill_sd_dreambooth/README.md
+++ b/configs/distill_sd_dreambooth/README.md
@@ -77,15 +77,21 @@ $ mim run diffengine demo_lora "A photo of sks dog in a bucket" work_dirs/small_
 
 #### small_sd_dreambooth_lora_dog
 
-![example1](https://github.com/okotaku/diffengine/assets/24734142/16cc3ef2-860d-4e4a-8b1d-8f56d9021db9)
+![example1](https://github.com/okotaku/diffengine/assets/24734142/9fa0bf8a-34f2-4e74-88b8-f33e249520e2)
 
 We uploaded pretrained checkpoint on [`takuoko/small-sd-dreambooth-lora-dog`](https://huggingface.co/takuoko/small-sd-dreambooth-lora-dog).
 
 #### tiny_sd_dreambooth_lora_dog
 
-![example2](https://github.com/okotaku/diffengine/assets/24734142/2d7f3f20-fff4-41f1-9b17-be7b19129769)
+![example2](https://github.com/okotaku/diffengine/assets/24734142/dcb3ff5b-995e-44bc-885c-6ed050eea24d)
 
-Note that the result of tiny sd is not good.
+#### small_sd_dreambooth_lora_keramer_face
+
+![example1](https://github.com/okotaku/diffengine/assets/24734142/ddbb2e54-f8be-46a6-a7ab-5bfb54bd29e6)
+
+#### tiny_sd_dreambooth_lora_keramer_face
+
+![example2](https://github.com/okotaku/diffengine/assets/24734142/45e46061-a0c2-4396-b0fd-1aab36c2e4e5)
 
 ## Reference
 

--- a/configs/distill_sd_dreambooth/small_sd_dreambooth_lora_dog.py
+++ b/configs/distill_sd_dreambooth/small_sd_dreambooth_lora_dog.py
@@ -4,3 +4,6 @@ _base_ = [
     '../_base_/schedules/stable_diffusion_1k.py',
     '../_base_/default_runtime.py'
 ]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}}, )), )

--- a/configs/distill_sd_dreambooth/small_sd_dreambooth_lora_keramer_face.py
+++ b/configs/distill_sd_dreambooth/small_sd_dreambooth_lora_keramer_face.py
@@ -10,13 +10,13 @@ train_dataloader = dict(
 
 train_dataloader = dict(
     dataset=dict(
-        instance_prompt='Portrait of a sks person',
-        class_prompt='Portrait of a person'), )
+        instance_prompt='Portrait photo of a sks person',
+        class_prompt='Portrait photo of a person'), )
 
 custom_hooks = [
     dict(
         type='VisualizationHook',
-        prompt=['Portrait of a sks person in suits'] * 4,
+        prompt=['Portrait photo of a sks person in suits'] * 4,
         by_epoch=False,
         interval=100),
     dict(type='LoRASaveHook'),

--- a/configs/distill_sd_dreambooth/small_sd_dreambooth_lora_keramer_face.py
+++ b/configs/distill_sd_dreambooth/small_sd_dreambooth_lora_keramer_face.py
@@ -1,0 +1,24 @@
+_base_ = [
+    '../_base_/models/small_sd_lora.py',
+    '../_base_/datasets/keramer_face_dreambooth.py',
+    '../_base_/schedules/stable_diffusion_1k.py',
+    '../_base_/default_runtime.py'
+]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}}, )), )
+
+train_dataloader = dict(
+    dataset=dict(
+        instance_prompt='Portrait of a sks person',
+        class_prompt='Portrait of a person'), )
+
+custom_hooks = [
+    dict(
+        type='VisualizationHook',
+        prompt=['Portrait of a sks person in suits'] * 4,
+        by_epoch=False,
+        interval=100),
+    dict(type='LoRASaveHook'),
+    dict(type='UnetEMAHook', momentum=1e-4, priority='ABOVE_NORMAL')
+]

--- a/configs/distill_sd_dreambooth/tiny_sd_dreambooth_lora_dog.py
+++ b/configs/distill_sd_dreambooth/tiny_sd_dreambooth_lora_dog.py
@@ -3,3 +3,6 @@ _base_ = [
     '../_base_/schedules/stable_diffusion_1k.py',
     '../_base_/default_runtime.py'
 ]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}}, )), )

--- a/configs/distill_sd_dreambooth/tiny_sd_dreambooth_lora_keramer_face.py
+++ b/configs/distill_sd_dreambooth/tiny_sd_dreambooth_lora_keramer_face.py
@@ -1,0 +1,25 @@
+_base_ = [
+    '../_base_/models/tiny_sd_lora.py',
+    '../_base_/datasets/keramer_face_dreambooth.py',
+    '../_base_/schedules/stable_diffusion_1k.py',
+    '../_base_/default_runtime.py'
+]
+
+train_dataloader = dict(
+    dataset=dict(
+        class_image_config=dict(
+            model={{_base_.model.model}},
+            data_dir='work_dirs/class_image2',
+        ),
+        instance_prompt='Portrait of a sks person',
+        class_prompt='Portrait of a person'), )
+
+custom_hooks = [
+    dict(
+        type='VisualizationHook',
+        prompt=['Portrait of a sks person in suits'] * 4,
+        by_epoch=False,
+        interval=100),
+    dict(type='LoRASaveHook'),
+    dict(type='UnetEMAHook', momentum=1e-4, priority='ABOVE_NORMAL')
+]

--- a/configs/distill_sd_dreambooth/tiny_sd_dreambooth_lora_keramer_face.py
+++ b/configs/distill_sd_dreambooth/tiny_sd_dreambooth_lora_keramer_face.py
@@ -7,17 +7,14 @@ _base_ = [
 
 train_dataloader = dict(
     dataset=dict(
-        class_image_config=dict(
-            model={{_base_.model.model}},
-            data_dir='work_dirs/class_image2',
-        ),
-        instance_prompt='Portrait of a sks person',
-        class_prompt='Portrait of a person'), )
+        class_image_config=dict(model={{_base_.model.model}}, ),
+        instance_prompt='Portrait photo of a sks person',
+        class_prompt='Portrait photo of a person'), )
 
 custom_hooks = [
     dict(
         type='VisualizationHook',
-        prompt=['Portrait of a sks person in suits'] * 4,
+        prompt=['Portrait photo of a sks person in suits'] * 4,
         by_epoch=False,
         interval=100),
     dict(type='LoRASaveHook'),

--- a/configs/stable_diffusion_dreambooth/stable_diffusion_v15_dreambooth_lora_dog.py
+++ b/configs/stable_diffusion_dreambooth/stable_diffusion_v15_dreambooth_lora_dog.py
@@ -4,3 +4,6 @@ _base_ = [
     '../_base_/schedules/stable_diffusion_1k.py',
     '../_base_/default_runtime.py'
 ]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}}, )), )

--- a/configs/stable_diffusion_dreambooth/stable_diffusion_v21_dreambooth_lora_dog.py
+++ b/configs/stable_diffusion_dreambooth/stable_diffusion_v21_dreambooth_lora_dog.py
@@ -13,4 +13,7 @@ train_pipeline = [
     dict(type='torchvision/Normalize', mean=[0.5], std=[0.5]),
     dict(type='PackInputs'),
 ]
-train_dataloader = dict(dataset=dict(pipeline=train_pipeline), )
+train_dataloader = dict(
+    dataset=dict(
+        class_image_config=dict(model={{_base_.model.model}}, ),
+        pipeline=train_pipeline))

--- a/configs/stable_diffusion_xl_dreambooth/stable_diffusion_xl_dreambooth_lora_dog.py
+++ b/configs/stable_diffusion_xl_dreambooth/stable_diffusion_xl_dreambooth_lora_dog.py
@@ -4,3 +4,6 @@ _base_ = [
     '../_base_/schedules/stable_diffusion_500.py',
     '../_base_/default_runtime.py'
 ]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}}, )), )

--- a/configs/stable_diffusion_xl_dreambooth/stable_diffusion_xl_dreambooth_lora_keramer_face.py
+++ b/configs/stable_diffusion_xl_dreambooth/stable_diffusion_xl_dreambooth_lora_keramer_face.py
@@ -4,3 +4,6 @@ _base_ = [
     '../_base_/schedules/stable_diffusion_500.py',
     '../_base_/default_runtime.py'
 ]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}}, )), )

--- a/configs/stable_diffusion_xl_dreambooth/stable_diffusion_xl_dreambooth_lora_potatehead.py
+++ b/configs/stable_diffusion_xl_dreambooth/stable_diffusion_xl_dreambooth_lora_potatehead.py
@@ -4,3 +4,6 @@ _base_ = [
     '../_base_/schedules/stable_diffusion_500.py',
     '../_base_/default_runtime.py'
 ]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}}, )), )

--- a/configs/stable_diffusion_xl_dreambooth/stable_diffusion_xl_dreambooth_lora_starbucks.py
+++ b/configs/stable_diffusion_xl_dreambooth/stable_diffusion_xl_dreambooth_lora_starbucks.py
@@ -4,3 +4,6 @@ _base_ = [
     '../_base_/schedules/stable_diffusion_500.py',
     '../_base_/default_runtime.py'
 ]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}}, )), )

--- a/diffengine/datasets/hf_dreambooth_datasets.py
+++ b/diffengine/datasets/hf_dreambooth_datasets.py
@@ -101,7 +101,8 @@ class HFDreamBoothDataset(Dataset):
 
     def generate_class_image(self, class_image_config):
         class_images_dir = Path(class_image_config['data_dir'])
-        if class_image_config['recreate_class_images']:
+        if class_images_dir.exists(
+        ) and class_image_config['recreate_class_images']:
             shutil.rmtree(class_images_dir)
         class_images_dir.mkdir(parents=True, exist_ok=True)
         cur_class_images = list(class_images_dir.iterdir())

--- a/diffengine/datasets/hf_dreambooth_datasets.py
+++ b/diffengine/datasets/hf_dreambooth_datasets.py
@@ -1,6 +1,7 @@
 import copy
 import hashlib
 import random
+import shutil
 from pathlib import Path
 from typing import Optional, Sequence
 
@@ -33,7 +34,9 @@ class HFDreamBoothDataset(Dataset):
             num_images (int): Minimal class images for prior preservation
                 loss. If there are not enough images already present in
                 class_data_dir, additional images will be sampled with
-                class_prompt.
+                class_prompt. Defaults to 200.
+            recreate_class_images (bool): Whether to re create all class
+                images. Defaults to True.
         class_prompt (Optional[str]): The prompt to specify images in the same
                 class as provided instance images. Defaults to None.
         pipeline (Sequence): Processing pipeline. Defaults to an empty tuple.
@@ -45,6 +48,7 @@ class HFDreamBoothDataset(Dataset):
         data_dir='work_dirs/class_image',
         num_images=200,
         device='cuda',
+        recreate_class_images=True,
     )
 
     def __init__(self,
@@ -56,6 +60,7 @@ class HFDreamBoothDataset(Dataset):
                      data_dir='work_dirs/class_image',
                      num_images=200,
                      device='cuda',
+                     recreate_class_images=True,
                  ),
                  class_prompt: Optional[str] = None,
                  pipeline: Sequence = (),
@@ -78,7 +83,10 @@ class HFDreamBoothDataset(Dataset):
 
         # generate class image
         if class_prompt is not None:
-            essential_keys = {'model', 'data_dir', 'num_images', 'device'}
+            essential_keys = {
+                'model', 'data_dir', 'num_images', 'device',
+                'recreate_class_images'
+            }
             _class_image_config = copy.deepcopy(
                 self.default_class_image_config)
             _class_image_config.update(class_image_config)
@@ -93,6 +101,8 @@ class HFDreamBoothDataset(Dataset):
 
     def generate_class_image(self, class_image_config):
         class_images_dir = Path(class_image_config['data_dir'])
+        if class_image_config['recreate_class_images']:
+            shutil.rmtree(class_images_dir)
         class_images_dir.mkdir(parents=True, exist_ok=True)
         cur_class_images = list(class_images_dir.iterdir())
         num_cur_images = len(cur_class_images)

--- a/tests/test_datasets/test_hf_dreambooth_datasets.py
+++ b/tests/test_datasets/test_hf_dreambooth_datasets.py
@@ -40,6 +40,7 @@ class TestHFDreamBoothDataset(RunnerTestCase):
                 data_dir='temp_dir/class_image',
                 num_images=1,
                 device='cpu',
+                recreate_class_images=True,
             ),
             pipeline=[
                 dict(type='PackInputs', skip_to_tensor_key=['img', 'text'])


### PR DESCRIPTION
## Motivation

Distill SD was distilled from SG161222/Realistic_Vision_V4.0 on a Subset of recastai/LAION-art-EN-improved-captions dataset. As a result, this model excels in enhancing performance for human faces.

## Modification

- Add Human face DreamBooth with Distill SD
- Fix DreamBooth bug that create class images with different base model.

## Results (Optional)

#### small_sd_dreambooth_lora_dog

![example1](https://github.com/okotaku/diffengine/assets/24734142/9fa0bf8a-34f2-4e74-88b8-f33e249520e2)

#### tiny_sd_dreambooth_lora_dog

![example2](https://github.com/okotaku/diffengine/assets/24734142/dcb3ff5b-995e-44bc-885c-6ed050eea24d)

#### small_sd_dreambooth_lora_keramer_face

![example1](https://github.com/okotaku/diffengine/assets/24734142/ddbb2e54-f8be-46a6-a7ab-5bfb54bd29e6)

#### tiny_sd_dreambooth_lora_keramer_face

![example2](https://github.com/okotaku/diffengine/assets/24734142/45e46061-a0c2-4396-b0fd-1aab36c2e4e5)

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
