### PR TITLE
[Feature] Support multi aspectratio resize

### DIFF
--- a/diffengine/datasets/__init__.py
+++ b/diffengine/datasets/__init__.py
@@ -1,6 +1,7 @@
 from .hf_controlnet_datasets import HFControlNetDataset
 from .hf_datasets import HFDataset
 from .hf_dreambooth_datasets import HFDreamBoothDataset
+from .samplers import *  # noqa: F401, F403
 from .transforms import *  # noqa: F401, F403
 
 __all__ = ['HFDataset', 'HFDreamBoothDataset', 'HFControlNetDataset']

--- a/diffengine/datasets/samplers/__init__.py
+++ b/diffengine/datasets/samplers/__init__.py
@@ -1,0 +1,3 @@
+from .batch_sampler import AspectRatioBatchSampler
+
+__all__ = ['AspectRatioBatchSampler']

--- a/diffengine/datasets/samplers/batch_sampler.py
+++ b/diffengine/datasets/samplers/batch_sampler.py
@@ -1,0 +1,75 @@
+# based on https://github.com/open-mmlab/mmdetection/blob/f78af7785ada87f1ced75a2313746e4ba3149760/mmdet/datasets/samplers/batch_sampler.py#L12  # noqa
+from typing import Sequence
+
+import numpy as np
+from torch.utils.data import BatchSampler, Sampler
+
+from diffengine.registry import DATA_SAMPLERS
+
+
+@DATA_SAMPLERS.register_module()
+class AspectRatioBatchSampler(BatchSampler):
+    """A sampler wrapper for grouping images with similar aspect ratio into a
+    same batch.
+
+    Args:
+        sampler (Sampler): Base sampler.
+        batch_size (int): Size of mini-batch.
+        drop_last (bool): If ``True``, the sampler will drop the last batch if
+            its size would be less than ``batch_size``.
+    """
+
+    def __init__(self,
+                 sampler: Sampler,
+                 batch_size: int,
+                 drop_last: bool = False) -> None:
+        if not isinstance(sampler, Sampler):
+            raise TypeError('sampler should be an instance of ``Sampler``, '
+                            f'but got {sampler}')
+        if not isinstance(batch_size, int) or batch_size <= 0:
+            raise ValueError('batch_size should be a positive integer value, '
+                             f'but got batch_size={batch_size}')
+        self.sampler = sampler
+        self.batch_size = batch_size
+        self.drop_last = drop_last
+        # two groups for w < h and w >= h
+        self._aspect_ratio_buckets = {}
+        # calc aspect ratio
+        self.bucket_ids = []
+        for idx in range(len(self.sampler.dataset)):
+            data_info = self.sampler.dataset[idx]
+            bucket_id = data_info['inputs']['img'].size(
+            )[1] / data_info['inputs']['img'].size()[2]
+            self.bucket_ids.append(bucket_id)
+
+    def __iter__(self) -> Sequence[int]:
+        for idx in self.sampler:
+            bucket_id = self.bucket_ids[idx]
+            if bucket_id not in self._aspect_ratio_buckets:
+                self._aspect_ratio_buckets[bucket_id] = []
+            bucket = self._aspect_ratio_buckets[bucket_id]
+            bucket.append(idx)
+            # yield a batch of indices in the same aspect ratio group
+            if len(bucket) == self.batch_size:
+                yield bucket[:]
+                del bucket[:]
+
+        # yield the rest data and reset the bucket
+        if not self.drop_last:
+            for _, v in self._aspect_ratio_buckets.items():
+                if len(v) > 0:
+                    yield v
+                    del v
+        self._aspect_ratio_buckets = {}
+
+    def __len__(self) -> int:
+        total_sample = 0
+        _, counts = np.unique(self.bucket_ids, return_counts=True)
+        for c in counts:
+            if self.drop_last:
+                total_sample += c // self.batch_size
+            else:
+                total_sample += c // self.batch_size
+                if c % self.batch_size != 0:
+                    total_sample += 1
+        return total_sample

--- a/diffengine/datasets/transforms/__init__.py
+++ b/diffengine/datasets/transforms/__init__.py
@@ -1,11 +1,12 @@
 from .base import BaseTransform
 from .dump_image import DumpImage
 from .formatting import PackInputs
-from .processing import (TRANSFORMS, CenterCrop, ComputeTimeIds, RandomCrop,
+from .processing import (TRANSFORMS, CenterCrop, ComputeTimeIds,
+                         MultiAspectRatioResizeCenterCrop, RandomCrop,
                          RandomHorizontalFlip, SaveImageShape)
 
 __all__ = [
     'BaseTransform', 'PackInputs', 'TRANSFORMS', 'SaveImageShape',
     'RandomCrop', 'CenterCrop', 'RandomHorizontalFlip', 'ComputeTimeIds',
-    'DumpImage'
+    'DumpImage', 'MultiAspectRatioResizeCenterCrop'
 ]

--- a/diffengine/registry.py
+++ b/diffengine/registry.py
@@ -1,3 +1,4 @@
+from mmengine.registry import DATA_SAMPLERS as MMENGINE_DATA_SAMPLERS
 from mmengine.registry import DATASETS as MMENGINE_DATASETS
 from mmengine.registry import FUNCTIONS as MMENGINE_FUNCTIONS
 from mmengine.registry import HOOKS as MMENGINE_HOOKS
@@ -6,8 +7,15 @@ from mmengine.registry import OPTIMIZERS as MMENGINE_OPTIMIZERS
 from mmengine.registry import TRANSFORMS as MMENGINE_TRANSFORMS
 from mmengine.registry import Registry
 
-__all__ = ['MODELS', 'DATASETS', 'HOOKS', 'FUNCTIONS', 'TRANSFORMS']
+__all__ = [
+    'MODELS', 'DATASETS', 'HOOKS', 'FUNCTIONS', 'TRANSFORMS', 'DATA_SAMPLERS',
+    'OPTIMIZERS'
+]
 
+DATA_SAMPLERS = Registry(
+    'data sampler',
+    parent=MMENGINE_DATA_SAMPLERS,
+    locations=['diffengine.datasets.samplers'])
 DATASETS = Registry(
     'dataset',
     parent=MMENGINE_DATASETS,

--- a/tests/test_datasets/test_samplers/test_batch_sampler.py
+++ b/tests/test_datasets/test_samplers/test_batch_sampler.py
@@ -1,0 +1,86 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+import torch
+from mmengine.dataset import DefaultSampler
+from torch.utils.data import Dataset
+
+from diffengine.datasets.samplers import AspectRatioBatchSampler
+
+
+class DummyDataset(Dataset):
+
+    def __init__(self, length):
+        self.length = length
+        self.shapes = [[32, 32] if i % 2 == 0 else [16, 48]
+                       for i in range(length)]
+
+    def __len__(self):
+        return self.length
+
+    def __getitem__(self, idx):
+        results = dict(
+            img=torch.zeros((3, self.shapes[idx][0], self.shapes[idx][1])),
+            aspect_ratio=self.shapes[idx][0] / self.shapes[idx][1])
+        return dict(inputs=results)
+
+
+class TestAspectRatioBatchSampler(TestCase):
+
+    @patch('mmengine.dist.get_dist_info', return_value=(0, 1))
+    def setUp(self, mock):
+        self.length = 100
+        self.dataset = DummyDataset(self.length)
+        self.sampler = DefaultSampler(self.dataset, shuffle=False)
+
+    def test_invalid_inputs(self):
+        with self.assertRaisesRegex(
+                ValueError, 'batch_size should be a positive integer value'):
+            AspectRatioBatchSampler(self.sampler, batch_size=-1)
+
+        with self.assertRaisesRegex(
+                TypeError, 'sampler should be an instance of ``Sampler``'):
+            AspectRatioBatchSampler(None, batch_size=1)
+
+    def test_divisible_batch(self):
+        batch_size = 5
+        batch_sampler = AspectRatioBatchSampler(
+            self.sampler, batch_size=batch_size, drop_last=True)
+        self.assertEqual(
+            len(batch_sampler), (self.length / 2 // batch_size) * 2)
+        for batch_idxs in batch_sampler:
+            self.assertEqual(len(batch_idxs), batch_size)
+            batch = [
+                self.dataset[idx]['inputs']['aspect_ratio']
+                for idx in batch_idxs
+            ]
+            for i in range(1, batch_size):
+                self.assertEqual(batch[0], batch[i])
+
+    def test_indivisible_batch(self):
+        batch_size = 7
+        batch_sampler = AspectRatioBatchSampler(
+            self.sampler, batch_size=batch_size, drop_last=True)
+        all_batch_idxs = list(batch_sampler)
+        self.assertEqual(
+            len(batch_sampler), (self.length / 2 // batch_size) * 2)
+        self.assertEqual(
+            len(all_batch_idxs), (self.length / 2 // batch_size) * 2)
+
+        batch_sampler = AspectRatioBatchSampler(
+            self.sampler, batch_size=batch_size, drop_last=False)
+        all_batch_idxs = list(batch_sampler)
+        self.assertEqual(
+            len(batch_sampler), (self.length / 2 // batch_size) * 2 + 2)
+        self.assertEqual(
+            len(all_batch_idxs), (self.length / 2 // batch_size) * 2 + 2)
+
+        # the last batch may not have the same aspect ratio
+        for batch_idxs in all_batch_idxs[:-2]:
+            self.assertEqual(len(batch_idxs), batch_size)
+            batch = [
+                self.dataset[idx]['inputs']['aspect_ratio']
+                for idx in batch_idxs
+            ]
+            for i in range(1, batch_size):
+                self.assertEqual(batch[0], batch[i])


### PR DESCRIPTION
## Motivation

Multiple input size training like [SDXL](https://arxiv.org/abs/2307.01952) and [NovelAI Aspect Ratio Bucketing](https://github.com/NovelAI/novelai-aspect-ratio-bucketing).

## Use cases (Optional)

```
dict(type='MultiAspectRatioResizeCenterCrop',
         sizes=[
             [640, 1536], [768, 1344], [832, 1216], [896, 1152],
             [1024, 1024], [1152, 896], [1216, 832], [1344, 768], [1536, 640]
             ],
         interpolation='bilinear'),



sampler=dict(type='DefaultSampler', shuffle=True),
batch_sampler=dict(type='AspectRatioBatchSampler'),
```

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.
