### PR TITLE
[Feature] Pre compute Text Embeddings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,8 @@
           "ms-vscode-remote.remote-ssh-edit",
           "ms-vscode.remote-explorer",
           "wayou.vscode-todo-highlight",
-          "Gruntfuggly.todo-tree"
+          "Gruntfuggly.todo-tree",
+          "streetsidesoftware.code-spell-checker"
         ]
       }
     }

--- a/configs/_base_/datasets/pokemon_blip_xl_pre_compute.py
+++ b/configs/_base_/datasets/pokemon_blip_xl_pre_compute.py
@@ -1,0 +1,38 @@
+train_pipeline = [
+    dict(type='SaveImageShape'),
+    dict(type='torchvision/Resize', size=1024, interpolation='bilinear'),
+    dict(type='RandomCrop', size=1024),
+    dict(type='RandomHorizontalFlip', p=0.5),
+    dict(type='ComputeTimeIds'),
+    dict(type='torchvision/ToTensor'),
+    dict(type='torchvision/Normalize', mean=[0.5], std=[0.5]),
+    dict(
+        type='PackInputs',
+        input_keys=[
+            'img', 'time_ids', 'prompt_embeds', 'pooled_prompt_embeds'
+        ]),
+]
+train_dataloader = dict(
+    batch_size=2,
+    num_workers=2,
+    dataset=dict(
+        type='HFDatasetPreComputeEmbs',
+        dataset='lambdalabs/pokemon-blip-captions',
+        text_hasher='text_pokemon_blip',
+        pipeline=train_pipeline),
+    sampler=dict(type='DefaultSampler', shuffle=True),
+)
+
+val_dataloader = None
+val_evaluator = None
+test_dataloader = val_dataloader
+test_evaluator = val_evaluator
+
+custom_hooks = [
+    dict(
+        type='VisualizationHook',
+        prompt=['yoda pokemon'] * 4,
+        height=1024,
+        width=1024),
+    dict(type='SDCheckpointHook')
+]

--- a/configs/_base_/datasets/pokemon_blip_xl_pre_compute.py
+++ b/configs/_base_/datasets/pokemon_blip_xl_pre_compute.py
@@ -19,6 +19,7 @@ train_dataloader = dict(
         type='HFDatasetPreComputeEmbs',
         dataset='lambdalabs/pokemon-blip-captions',
         text_hasher='text_pokemon_blip',
+        model='stabilityai/stable-diffusion-xl-base-1.0',
         pipeline=train_pipeline),
     sampler=dict(type='DefaultSampler', shuffle=True),
 )

--- a/configs/stable_diffusion_xl/README.md
+++ b/configs/stable_diffusion_xl/README.md
@@ -76,3 +76,7 @@ You can see more details on [`docs/source/run_guides/run_xl.md`](../../docs/sour
 #### stable_diffusion_xl_pokemon_blip
 
 ![example1](https://github.com/okotaku/diffengine/assets/24734142/dd04fb22-64fb-4c4f-8164-b8391d94abab)
+
+#### stable_diffusion_xl_pokemon_blip_pre_compute
+
+![example2](https://github.com/okotaku/diffengine/assets/24734142/5da59a56-ce36-48cc-b113-007f8b9faeba)

--- a/configs/stable_diffusion_xl/stable_diffusion_xl_pokemon_blip_pre_compute.py
+++ b/configs/stable_diffusion_xl/stable_diffusion_xl_pokemon_blip_pre_compute.py
@@ -1,0 +1,12 @@
+_base_ = [
+    '../_base_/models/stable_diffusion_xl.py',
+    '../_base_/datasets/pokemon_blip_xl_pre_compute.py',
+    '../_base_/schedules/stable_diffusion_xl_50e.py',
+    '../_base_/default_runtime.py'
+]
+
+model = dict(pre_compute_text_embeddings=True)
+
+train_dataloader = dict(batch_size=1)
+
+optim_wrapper_cfg = dict(accumulative_counts=4)  # update every four times

--- a/diffengine/datasets/__init__.py
+++ b/diffengine/datasets/__init__.py
@@ -1,7 +1,10 @@
 from .hf_controlnet_datasets import HFControlNetDataset
-from .hf_datasets import HFDataset
+from .hf_datasets import HFDataset, HFDatasetPreComputeEmbs
 from .hf_dreambooth_datasets import HFDreamBoothDataset
 from .samplers import *  # noqa: F401, F403
 from .transforms import *  # noqa: F401, F403
 
-__all__ = ['HFDataset', 'HFDreamBoothDataset', 'HFControlNetDataset']
+__all__ = [
+    'HFDataset', 'HFDreamBoothDataset', 'HFControlNetDataset',
+    'HFDatasetPreComputeEmbs'
+]

--- a/diffengine/datasets/utils.py
+++ b/diffengine/datasets/utils.py
@@ -1,0 +1,56 @@
+import random
+from typing import Dict
+
+import numpy as np
+import torch
+
+
+def encode_prompt_sdxl(batch,
+                       text_encoders,
+                       tokenizers,
+                       proportion_empty_prompts,
+                       caption_column,
+                       is_train: bool = True) -> Dict[torch.Tensor]:
+    # Adapted from pipelines.StableDiffusionXLPipeline.encode_prompt
+    prompt_embeds_list = []
+    prompt_batch = batch[caption_column]
+
+    captions = []
+    for caption in prompt_batch:
+        if random.random() < proportion_empty_prompts:
+            captions.append('')
+        elif isinstance(caption, str):
+            captions.append(caption)
+        elif isinstance(caption, (list, np.ndarray)):
+            # take a random caption if there are multiple
+            captions.append(random.choice(caption) if is_train else caption[0])
+
+    with torch.no_grad():
+        for tokenizer, text_encoder in zip(tokenizers, text_encoders):
+            text_inputs = tokenizer(
+                captions,
+                padding='max_length',
+                max_length=tokenizer.model_max_length,
+                truncation=True,
+                return_tensors='pt',
+            )
+            text_input_ids = text_inputs.input_ids
+            prompt_embeds = text_encoder(
+                text_input_ids.to(text_encoder.device),
+                output_hidden_states=True,
+            )
+
+            # We are only ALWAYS interested in the pooled output of the final
+            # text encoder
+            pooled_prompt_embeds = prompt_embeds[0]
+            prompt_embeds = prompt_embeds.hidden_states[-2]
+            bs_embed, seq_len, _ = prompt_embeds.shape
+            prompt_embeds = prompt_embeds.view(bs_embed, seq_len, -1)
+            prompt_embeds_list.append(prompt_embeds)
+
+    prompt_embeds = torch.concat(prompt_embeds_list, dim=-1)
+    pooled_prompt_embeds = pooled_prompt_embeds.view(bs_embed, -1)
+    return {
+        'prompt_embeds': prompt_embeds.cpu(),
+        'pooled_prompt_embeds': pooled_prompt_embeds.cpu()
+    }

--- a/diffengine/datasets/utils.py
+++ b/diffengine/datasets/utils.py
@@ -10,7 +10,7 @@ def encode_prompt_sdxl(batch,
                        tokenizers,
                        proportion_empty_prompts,
                        caption_column,
-                       is_train: bool = True) -> Dict[torch.Tensor]:
+                       is_train: bool = True) -> Dict[str, torch.Tensor]:
     # Adapted from pipelines.StableDiffusionXLPipeline.encode_prompt
     prompt_embeds_list = []
     prompt_batch = batch[caption_column]

--- a/diffengine/models/editors/stable_diffusion_xl/sdxl_data_preprocessor.py
+++ b/diffengine/models/editors/stable_diffusion_xl/sdxl_data_preprocessor.py
@@ -34,4 +34,11 @@ class SDXLDataPreprocessor(BaseDataPreprocessor):
 
         data['inputs']['img'] = torch.stack(data['inputs']['img'])
         data['inputs']['time_ids'] = torch.stack(data['inputs']['time_ids'])
+        # pre-compute text embeddings
+        if 'prompt_embeds' in data['inputs']:
+            data['inputs']['prompt_embeds'] = torch.stack(
+                data['inputs']['prompt_embeds'])
+        if 'pooled_prompt_embeds' in data['inputs']:
+            data['inputs']['pooled_prompt_embeds'] = torch.stack(
+                data['inputs']['pooled_prompt_embeds'])
         return super().forward(data)  # type: ignore

--- a/tests/test_datasets/test_hf_datasets.py
+++ b/tests/test_datasets/test_hf_datasets.py
@@ -1,7 +1,8 @@
+import numpy as np
 from mmengine.testing import RunnerTestCase
 from PIL import Image
 
-from diffengine.datasets import HFDataset
+from diffengine.datasets import HFDataset, HFDatasetPreComputeEmbs
 
 
 class TestHFDataset(RunnerTestCase):
@@ -24,5 +25,24 @@ class TestHFDataset(RunnerTestCase):
 
         data = dataset[0]
         assert data['text'] == 'a cat'
+        self.assertIsInstance(data['img'], Image.Image)
+        assert data['img'].width == 400
+
+
+class TestHFDatasetPreComputeEmbs(RunnerTestCase):
+
+    def test_dataset_from_local(self):
+        dataset = HFDatasetPreComputeEmbs(
+            dataset='tests/testdata/dataset',
+            model='hf-internal-testing/tiny-stable-diffusion-xl-pipe',
+            image_column='file_name')
+        assert len(dataset) == 1
+
+        data = dataset[0]
+        assert 'text' not in data
+        self.assertEqual(type(data['prompt_embeds']), list)
+        self.assertEqual(type(data['pooled_prompt_embeds']), list)
+        self.assertEqual(np.array(data['prompt_embeds']).shape, (77, 64))
+        self.assertEqual(np.array(data['pooled_prompt_embeds']).shape, (32, ))
         self.assertIsInstance(data['img'], Image.Image)
         assert data['img'].width == 400

--- a/tests/test_datasets/test_hf_datasets.py
+++ b/tests/test_datasets/test_hf_datasets.py
@@ -35,7 +35,8 @@ class TestHFDatasetPreComputeEmbs(RunnerTestCase):
         dataset = HFDatasetPreComputeEmbs(
             dataset='tests/testdata/dataset',
             model='hf-internal-testing/tiny-stable-diffusion-xl-pipe',
-            image_column='file_name')
+            image_column='file_name',
+            device='cpu')
         assert len(dataset) == 1
 
         data = dataset[0]

--- a/tests/test_models/test_editors/test_stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/test_models/test_editors/test_stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -26,6 +26,28 @@ class TestStableDiffusionXL(TestCase):
         # test device
         assert StableDiffuser.device.type == 'cpu'
 
+    def test_infer_with_pre_compute_embs(self):
+        StableDiffuser = StableDiffusionXL(
+            'hf-internal-testing/tiny-stable-diffusion-xl-pipe',
+            pre_compute_text_embeddings=True,
+            data_preprocessor=SDXLDataPreprocessor())
+
+        assert not hasattr(StableDiffuser, 'tokenizer_one')
+        assert not hasattr(StableDiffuser, 'text_encoder_one')
+        assert not hasattr(StableDiffuser, 'tokenizer_two')
+        assert not hasattr(StableDiffuser, 'text_encoder_two')
+
+        # test infer
+        result = StableDiffuser.infer(
+            ['an insect robot preparing a delicious meal'],
+            height=64,
+            width=64)
+        assert len(result) == 1
+        assert result[0].shape == (64, 64, 3)
+
+        # test device
+        assert StableDiffuser.device.type == 'cpu'
+
     def test_train_step(self):
         # test load with loss module
         StableDiffuser = StableDiffusionXL(
@@ -58,6 +80,32 @@ class TestStableDiffusionXL(TestCase):
             inputs=dict(
                 img=[torch.zeros((3, 64, 64))],
                 text=['a dog'],
+                time_ids=[torch.zeros((1, 6))]))
+        optimizer = SGD(StableDiffuser.parameters(), lr=0.1)
+        optim_wrapper = OptimWrapper(optimizer)
+        log_vars = StableDiffuser.train_step(data, optim_wrapper)
+        assert log_vars
+        self.assertIsInstance(log_vars['loss'], torch.Tensor)
+
+    def test_train_step_with_pre_compute_embs(self):
+        # test load with loss module
+        StableDiffuser = StableDiffusionXL(
+            'hf-internal-testing/tiny-stable-diffusion-xl-pipe',
+            pre_compute_text_embeddings=True,
+            loss=L2Loss(),
+            data_preprocessor=SDXLDataPreprocessor())
+
+        assert not hasattr(StableDiffuser, 'tokenizer_one')
+        assert not hasattr(StableDiffuser, 'text_encoder_one')
+        assert not hasattr(StableDiffuser, 'tokenizer_two')
+        assert not hasattr(StableDiffuser, 'text_encoder_two')
+
+        # test train step
+        data = dict(
+            inputs=dict(
+                img=[torch.zeros((3, 64, 64))],
+                prompt_embeds=[torch.zeros((77, 64))],
+                pooled_prompt_embeds=[torch.zeros((32))],
                 time_ids=[torch.zeros((1, 6))]))
         optimizer = SGD(StableDiffuser.parameters(), lr=0.1)
         optim_wrapper = OptimWrapper(optimizer)


### PR DESCRIPTION
## Motivation

Support `Pre compute Text Embeddings` to speedup and reduce memory for training.

## Results (Optional)

#### stable_diffusion_xl_pokemon_blip_pre_compute

![example2](https://github.com/okotaku/diffengine/assets/24734142/5da59a56-ce36-48cc-b113-007f8b9faeba)

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
