### PR TITLE
[Enhance] Fix more epochs for IP Adapter Plus

### DIFF
--- a/configs/ip_adapter/README.md
+++ b/configs/ip_adapter/README.md
@@ -82,4 +82,4 @@ You can see more details on [`docs/source/run_guides/run_ip_adapter.md`](../../d
 
 ![input1](https://datasets-server.huggingface.co/assets/lambdalabs/pokemon-blip-captions/--/default/train/0/image/image.jpg)
 
-![example1](https://github.com/okotaku/diffengine/assets/24734142/1052b1c4-2b2b-4cc1-85e5-63912f96dfc7)
+![example1](https://github.com/okotaku/diffengine/assets/24734142/723ad39d-9e0f-441b-80f7-cf9bcfd12853)

--- a/configs/ip_adapter/stable_diffusion_xl_pokemon_blip_ip_adapter_plus.py
+++ b/configs/ip_adapter/stable_diffusion_xl_pokemon_blip_ip_adapter_plus.py
@@ -8,3 +8,5 @@ _base_ = [
 train_dataloader = dict(batch_size=1)
 
 optim_wrapper_cfg = dict(accumulative_counts=4)  # update every four times
+
+train_cfg = dict(by_epoch=True, max_epochs=100)


### PR DESCRIPTION
## Results (Optional)

#### stable_diffusion_xl_pokemon_blip_ip_adapter_plus

![input1](https://datasets-server.huggingface.co/assets/lambdalabs/pokemon-blip-captions/--/default/train/0/image/image.jpg)

![example1](https://github.com/okotaku/diffengine/assets/24734142/723ad39d-9e0f-441b-80f7-cf9bcfd12853)

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
