### PR TITLE
[Feature] Faster train with torch.compile

### DIFF
--- a/configs/stable_diffusion_xl/README.md
+++ b/configs/stable_diffusion_xl/README.md
@@ -43,7 +43,9 @@ Settings:
 |                  Model                  | total time |
 | :-------------------------------------: | :--------: |
 | stable_diffusion_xl_pokemon_blip (fp16) | 12 m 37 s  |
-|  stable_diffusion_xl_pokemon_blip_fast  | 12 m 10 s  |
+|  stable_diffusion_xl_pokemon_blip_fast  |  9 m 47 s  |
+
+Note that `stable_diffusion_xl_pokemon_blip_fast` took a few minutes to compile. We will disregard it.
 
 ## Inference with diffusers
 

--- a/configs/stable_diffusion_xl/stable_diffusion_xl_pokemon_blip_fast.py
+++ b/configs/stable_diffusion_xl/stable_diffusion_xl_pokemon_blip_fast.py
@@ -5,6 +5,9 @@ _base_ = [
     "../_base_/default_runtime.py",
 ]
 
+model = dict(
+    gradient_checkpointing=False)
+
 train_dataloader = dict(batch_size=1)
 
 optim_wrapper = dict(
@@ -22,5 +25,6 @@ custom_hooks = [
         height=1024,
         width=1024),
     dict(type="SDCheckpointHook"),
-    dict(type="FastNormHook"),
+    dict(type="FastNormHook", fuse_unet_ln=False),
+    dict(type="CompileHook", compile_unet=True),
 ]

--- a/diffengine/engine/hooks/compile_hook.py
+++ b/diffengine/engine/hooks/compile_hook.py
@@ -12,13 +12,16 @@ class CompileHook(Hook):
     ----
         backend (str): The backend to use for compilation.
             Defaults to "inductor".
+        compile_unet (bool): Whether to compile the unet. Defaults to False.
     """
 
     priority = "VERY_LOW"
 
-    def __init__(self, backend: str = "inductor") -> None:
+    def __init__(self, backend: str = "inductor", *,
+                 compile_unet: bool = False) -> None:
         super().__init__()
         self.backend = backend
+        self.compile_unet = compile_unet
 
     def before_train(self, runner) -> None:
         """Compile the model.
@@ -30,7 +33,9 @@ class CompileHook(Hook):
         model = runner.model
         if is_model_wrapper(model):
             model = model.module
-        model.unet = torch.compile(model.unet, backend=self.backend)
+        if self.compile_unet:
+            model.unet = torch.compile(model.unet, backend=self.backend)
+
         if hasattr(model, "text_encoder"):
             model.text_encoder = torch.compile(
                 model.text_encoder, backend=self.backend)

--- a/tests/test_engine/test_hooks/test_compile_hook.py
+++ b/tests/test_engine/test_hooks/test_compile_hook.py
@@ -44,7 +44,7 @@ class TestCompileHook(RunnerTestCase):
         cfg.model.type = "StableDiffusion"
         cfg.model.model = "diffusers/tiny-stable-diffusion-torch"
         runner = self.build_runner(cfg)
-        hook = CompileHook()
+        hook = CompileHook(compile_unet=True)
         assert isinstance(runner.model.unet, UNet2DConditionModel)
         assert isinstance(runner.model.vae, AutoencoderKL)
         assert isinstance(runner.model.text_encoder, CLIPTextModel)
@@ -59,7 +59,7 @@ class TestCompileHook(RunnerTestCase):
         cfg.model.type = "StableDiffusionXL"
         cfg.model.model = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
         runner = self.build_runner(cfg)
-        hook = CompileHook()
+        hook = CompileHook(compile_unet=True)
         assert isinstance(runner.model.unet, UNet2DConditionModel)
         assert isinstance(runner.model.vae, AutoencoderKL)
         assert isinstance(runner.model.text_encoder_one, CLIPTextModel)

--- a/tests/test_engine/test_hooks/test_fast_norm_hook.py
+++ b/tests/test_engine/test_hooks/test_fast_norm_hook.py
@@ -53,7 +53,7 @@ class TestFastNormHook(RunnerTestCase):
         cfg.model.type = "StableDiffusion"
         cfg.model.model = "diffusers/tiny-stable-diffusion-torch"
         runner = self.build_runner(cfg)
-        hook = FastNormHook(fuse_text_encoder=True)
+        hook = FastNormHook(fuse_text_encoder_ln=True)
         assert isinstance(
             runner.model.unet.down_blocks[
                 1].attentions[0].transformer_blocks[0].norm1, nn.LayerNorm)
@@ -74,7 +74,7 @@ class TestFastNormHook(RunnerTestCase):
         cfg.model.type = "StableDiffusionXL"
         cfg.model.model = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
         runner = self.build_runner(cfg)
-        hook = FastNormHook(fuse_text_encoder=True)
+        hook = FastNormHook(fuse_text_encoder_ln=True)
         assert isinstance(
             runner.model.unet.down_blocks[
                 1].attentions[0].transformer_blocks[0].norm1, nn.LayerNorm)


### PR DESCRIPTION
## Motivation

Use `torch.compile`. Del `gradient_checkpointing`.

## Results (Optional)

|                  Model                  | total time |
| :-------------------------------------: | :--------: |
| stable_diffusion_xl_pokemon_blip (fp16) | 12 m 37 s  |
|  stable_diffusion_xl_pokemon_blip_fast  |  9 m 47 s  |

Note that `stable_diffusion_xl_pokemon_blip_fast` took a few minutes to compile. We will disregard it.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.
