### PR TITLE
[Enhance] Support compile mode

### DIFF
--- a/diffengine/engine/hooks/compile_hook.py
+++ b/diffengine/engine/hooks/compile_hook.py
@@ -12,15 +12,17 @@ class CompileHook(Hook):
     ----
         backend (str): The backend to use for compilation.
             Defaults to "inductor".
+        mode (str): The mode to use for compilation. Defaults to None.
         compile_unet (bool): Whether to compile the unet. Defaults to False.
     """
 
     priority = "VERY_LOW"
 
-    def __init__(self, backend: str = "inductor", *,
+    def __init__(self, backend: str = "inductor", mode: str | None = None, *,
                  compile_unet: bool = False) -> None:
         super().__init__()
         self.backend = backend
+        self.mode = mode
         self.compile_unet = compile_unet
 
     def before_train(self, runner) -> None:
@@ -34,17 +36,18 @@ class CompileHook(Hook):
         if is_model_wrapper(model):
             model = model.module
         if self.compile_unet:
-            model.unet = torch.compile(model.unet, backend=self.backend)
+            model.unet = torch.compile(model.unet, backend=self.backend,
+                                       mode=self.mode)
 
         if hasattr(model, "text_encoder"):
             model.text_encoder = torch.compile(
-                model.text_encoder, backend=self.backend)
+                model.text_encoder, backend=self.backend, mode=self.mode)
         if hasattr(model, "text_encoder_one"):
             model.text_encoder_one = torch.compile(
-                model.text_encoder_one, backend=self.backend)
+                model.text_encoder_one, backend=self.backend, mode=self.mode)
         if hasattr(model, "text_encoder_two"):
             model.text_encoder_two = torch.compile(
-                model.text_encoder_two, backend=self.backend)
+                model.text_encoder_two, backend=self.backend, mode=self.mode)
         if hasattr(model, "vae"):
             model.vae = torch.compile(
-                model.vae, backend=self.backend)
+                model.vae, backend=self.backend, mode=self.mode)


### PR DESCRIPTION
## Results (Optional)

|                  Model                  | total time |
| :-------------------------------------: | :--------: |
| stable_diffusion_xl_pokemon_blip_fast | 9 m 47 s  |
|  +compile mode="reduce-overhead”  |  9 m 15 s  |

Note that `mode="reduce-overhead”` creates a strict graph, which means that the validation method cannot be executed.

## Use cases (Optional)

```
dict(type="CompileHook", compile_unet=True, mode="reduce-overhead”),
```

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.


<!-- readthedocs-preview DiffEngine start -->
----
:books: Documentation preview :books:: https://DiffEngine--86.org.readthedocs.build/en/86/

<!-- readthedocs-preview DiffEngine end -->