### PR TITLE
[Feature] Support TimeSteps Bias

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ For detailed user guides and advanced guides, please refer to our [Documentation
             <li><a href="configs/offset_noise/README.md">Offset Noise (2023)</a></li>
             <li><a href="configs/pyramid_noise/README.md">Pyramid Noise (2023)</a></li>
             <li><a href="configs/input_perturbation/README.md">Input Perturbation (2023)</a></li>
+            <li><a href="configs/timesteps_bias/README.md">Time Steps Bias (2023)</a></li>
       </ul>
       </td>
     </tr>

--- a/configs/timesteps_bias/README.md
+++ b/configs/timesteps_bias/README.md
@@ -37,4 +37,12 @@ You can see more details on [`docs/source/run_guides/run_xl.md`](../../docs/sour
 
 #### stable_diffusion_xl_pokemon_blip_later_bias
 
-![example1](<>)
+![example1](https://github.com/okotaku/diffengine/assets/24734142/99f2139d-84f4-4658-8eb2-377216de2b0d)
+
+#### stable_diffusion_xl_pokemon_blip_earlier_bias
+
+![example2](https://github.com/okotaku/diffengine/assets/24734142/4a353bcd-44f3-4066-a095-09696cb09d6f)
+
+#### stable_diffusion_xl_pokemon_blip_range_bias
+
+![example3](https://github.com/okotaku/diffengine/assets/24734142/13b9b041-9103-4f04-8e19-569d59a55bcf)

--- a/configs/timesteps_bias/README.md
+++ b/configs/timesteps_bias/README.md
@@ -1,0 +1,40 @@
+# Time Steps Bias
+
+[Time Steps Bias](https://github.com/huggingface/diffusers/pull/5094)
+
+## Abstract
+
+TBD
+
+<div align=center>
+<img src=""/>
+</div>
+
+## Citation
+
+```
+```
+
+## Run Training
+
+Run Training
+
+```
+# single gpu
+$ mim train diffengine ${CONFIG_FILE}
+# multi gpus
+$ mim train diffengine ${CONFIG_FILE} --gpus 2 --launcher pytorch
+
+# Example.
+$ mim train diffengine configs/timesteps_bias/stable_diffusion_xl_pokemon_blip_later_bias.py
+```
+
+## Inference with diffusers
+
+You can see more details on [`docs/source/run_guides/run_xl.md`](../../docs/source/run_guides/run_xl.md#inference-with-diffusers).
+
+## Results Example
+
+#### stable_diffusion_xl_pokemon_blip_later_bias
+
+![example1](<>)

--- a/configs/timesteps_bias/stable_diffusion_xl_pokemon_blip_earlier_bias.py
+++ b/configs/timesteps_bias/stable_diffusion_xl_pokemon_blip_earlier_bias.py
@@ -1,0 +1,12 @@
+_base_ = [
+    "../_base_/models/stable_diffusion_xl.py",
+    "../_base_/datasets/pokemon_blip_xl.py",
+    "../_base_/schedules/stable_diffusion_xl_50e.py",
+    "../_base_/default_runtime.py",
+]
+
+model = dict(timesteps_generator=dict(type="EarlierTimeSteps"))
+
+train_dataloader = dict(batch_size=1)
+
+optim_wrapper_cfg = dict(accumulative_counts=4)  # update every four times

--- a/configs/timesteps_bias/stable_diffusion_xl_pokemon_blip_later_bias.py
+++ b/configs/timesteps_bias/stable_diffusion_xl_pokemon_blip_later_bias.py
@@ -1,0 +1,12 @@
+_base_ = [
+    "../_base_/models/stable_diffusion_xl.py",
+    "../_base_/datasets/pokemon_blip_xl.py",
+    "../_base_/schedules/stable_diffusion_xl_50e.py",
+    "../_base_/default_runtime.py",
+]
+
+model = dict(timesteps_generator=dict(type="LaterTimeSteps"))
+
+train_dataloader = dict(batch_size=1)
+
+optim_wrapper_cfg = dict(accumulative_counts=4)  # update every four times

--- a/configs/timesteps_bias/stable_diffusion_xl_pokemon_blip_range_bias.py
+++ b/configs/timesteps_bias/stable_diffusion_xl_pokemon_blip_range_bias.py
@@ -1,0 +1,12 @@
+_base_ = [
+    "../_base_/models/stable_diffusion_xl.py",
+    "../_base_/datasets/pokemon_blip_xl.py",
+    "../_base_/schedules/stable_diffusion_xl_50e.py",
+    "../_base_/default_runtime.py",
+]
+
+model = dict(timesteps_generator=dict(type="RangeTimeSteps"))
+
+train_dataloader = dict(batch_size=1)
+
+optim_wrapper_cfg = dict(accumulative_counts=4)  # update every four times

--- a/diffengine/models/editors/deepfloyd_if/deepfloyd_if.py
+++ b/diffengine/models/editors/deepfloyd_if/deepfloyd_if.py
@@ -41,6 +41,8 @@ class DeepFloydIF(BaseModel):
             :class:`SDDataPreprocessor`.
         noise_generator (dict, optional): The noise generator config.
             Defaults to ``dict(type='WhiteNoise')``.
+        timesteps_generator (dict, optional): The timesteps generator config.
+            Defaults to ``dict(type='TimeSteps')``.
         input_perturbation_gamma (float): The gamma of input perturbation.
             The recommended value is 0.1 for Input Perturbation.
             Defaults to 0.0.
@@ -61,6 +63,7 @@ class DeepFloydIF(BaseModel):
         prediction_type: str | None = None,
         data_preprocessor: dict | nn.Module | None = None,
         noise_generator: dict | None = None,
+        timesteps_generator: dict | None = None,
         input_perturbation_gamma: float = 0.0,
         *,
         finetune_text_encoder: bool = False,
@@ -70,6 +73,8 @@ class DeepFloydIF(BaseModel):
             data_preprocessor = {"type": "SDDataPreprocessor"}
         if noise_generator is None:
             noise_generator = {"type": "WhiteNoise"}
+        if timesteps_generator is None:
+            timesteps_generator = {"type": "TimeSteps"}
         if loss is None:
             loss = {"type": "L2Loss", "loss_weight": 1.0}
         super().__init__(data_preprocessor=data_preprocessor)
@@ -98,6 +103,7 @@ class DeepFloydIF(BaseModel):
         self.unet = UNet2DConditionModel.from_pretrained(
             model, subfolder="unet")
         self.noise_generator = MODELS.build(noise_generator)
+        self.timesteps_generator = MODELS.build(timesteps_generator)
         self.prepare_model()
         self.set_lora()
 
@@ -252,6 +258,7 @@ class DeepFloydIF(BaseModel):
                                 latents: torch.Tensor,
                                 noise: torch.Tensor,
                                 timesteps: torch.Tensor) -> torch.Tensor:
+        """Preprocess model input."""
         if self.input_perturbation_gamma > 0:
             input_noise = noise + self.input_perturbation_gamma * torch.randn_like(
                 noise)
@@ -300,12 +307,8 @@ class DeepFloydIF(BaseModel):
 
         noise = self.noise_generator(model_input)
 
-        num_batches = model_input.shape[0]
-        timesteps = torch.randint(
-            0,
-            self.scheduler.config.num_train_timesteps, (num_batches, ),
-            device=self.device)
-        timesteps = timesteps.long()
+        timesteps = self.timesteps_generator(self.scheduler, num_batches,
+                                            self.device)
 
         noisy_model_input = self._preprocess_model_input(model_input, noise,
                                                      timesteps)

--- a/diffengine/models/editors/distill_sd/distill_sd_xl.py
+++ b/diffengine/models/editors/distill_sd/distill_sd_xl.py
@@ -163,11 +163,8 @@ class DistillSDXL(StableDiffusionXL):
 
         noise = self.noise_generator(latents)
 
-        timesteps = torch.randint(
-            0,
-            self.scheduler.config.num_train_timesteps, (num_batches, ),
-            device=self.device)
-        timesteps = timesteps.long()
+        timesteps = self.timesteps_generator(self.scheduler, num_batches,
+                                            self.device)
 
         noisy_latents = self._preprocess_model_input(latents, noise, timesteps)
 

--- a/diffengine/models/editors/esd/esd_xl.py
+++ b/diffengine/models/editors/esd/esd_xl.py
@@ -60,6 +60,10 @@ class ESDXL(StableDiffusionXL):
 
         Disable gradient for some models.
         """
+        # Replace the noise generator and timesteps generator with None
+        self.noise_generator = None
+        self.timesteps_generator = None
+
         if self.lora_config is None:
             self.orig_unet = deepcopy(
                 self.unet).requires_grad_(requires_grad=False)
@@ -81,6 +85,13 @@ class ESDXL(StableDiffusionXL):
         """Convert the model into training mode."""
         super().train(mode)
         self._freeze_unet()
+
+    def _preprocess_model_input(self,
+                                latents: torch.Tensor,
+                                noise: torch.Tensor,
+                                timesteps: torch.Tensor) -> torch.Tensor:
+        """Preprocess model input."""
+        raise NotImplementedError
 
     def forward(
             self,

--- a/diffengine/models/editors/instruct_pix2pix/instruct_pix2pix_xl.py
+++ b/diffengine/models/editors/instruct_pix2pix/instruct_pix2pix_xl.py
@@ -183,11 +183,8 @@ class StableDiffusionXLInstructPix2Pix(StableDiffusionXL):
 
         noise = self.noise_generator(latents)
 
-        timesteps = torch.randint(
-            0,
-            self.scheduler.config.num_train_timesteps, (num_batches, ),
-            device=self.device)
-        timesteps = timesteps.long()
+        timesteps = self.timesteps_generator(self.scheduler, num_batches,
+                                            self.device)
 
         noisy_latents = self._preprocess_model_input(latents, noise, timesteps)
 

--- a/diffengine/models/editors/ip_adapter/ip_adapter_xl.py
+++ b/diffengine/models/editors/ip_adapter/ip_adapter_xl.py
@@ -244,11 +244,8 @@ class IPAdapterXL(StableDiffusionXL):
 
         noise = self.noise_generator(latents)
 
-        timesteps = torch.randint(
-            0,
-            self.scheduler.config.num_train_timesteps, (num_batches, ),
-            device=self.device)
-        timesteps = timesteps.long()
+        timesteps = self.timesteps_generator(self.scheduler, num_batches,
+                                            self.device)
 
         noisy_latents = self._preprocess_model_input(latents, noise, timesteps)
 
@@ -399,11 +396,8 @@ class IPAdapterXLPlus(IPAdapterXL):
 
         noise = self.noise_generator(latents)
 
-        timesteps = torch.randint(
-            0,
-            self.scheduler.config.num_train_timesteps, (num_batches, ),
-            device=self.device)
-        timesteps = timesteps.long()
+        timesteps = self.timesteps_generator(self.scheduler, num_batches,
+                                            self.device)
 
         noisy_latents = self._preprocess_model_input(latents, noise, timesteps)
 

--- a/diffengine/models/editors/stable_diffusion_controlnet/stable_diffusion_controlnet.py
+++ b/diffengine/models/editors/stable_diffusion_controlnet/stable_diffusion_controlnet.py
@@ -211,12 +211,8 @@ class StableDiffusionControlNet(StableDiffusion):
 
         noise = self.noise_generator(latents)
 
-        num_batches = latents.shape[0]
-        timesteps = torch.randint(
-            0,
-            self.scheduler.config.num_train_timesteps, (num_batches, ),
-            device=self.device)
-        timesteps = timesteps.long()
+        timesteps = self.timesteps_generator(self.scheduler, num_batches,
+                                            self.device)
 
         noisy_latents = self._preprocess_model_input(latents, noise, timesteps)
 

--- a/diffengine/models/editors/stable_diffusion_xl/stable_diffusion_xl.py
+++ b/diffengine/models/editors/stable_diffusion_xl/stable_diffusion_xl.py
@@ -67,6 +67,8 @@ class StableDiffusionXL(BaseModel):
             :class:`SDXLDataPreprocessor`.
         noise_generator (dict, optional): The noise generator config.
             Defaults to ``dict(type='WhiteNoise')``.
+        timesteps_generator (dict, optional): The timesteps generator config.
+            Defaults to ``dict(type='TimeSteps')``.
         input_perturbation_gamma (float): The gamma of input perturbation.
             The recommended value is 0.1 for Input Perturbation.
             Defaults to 0.0.
@@ -89,6 +91,7 @@ class StableDiffusionXL(BaseModel):
         prediction_type: str | None = None,
         data_preprocessor: dict | nn.Module | None = None,
         noise_generator: dict | None = None,
+        timesteps_generator: dict | None = None,
         input_perturbation_gamma: float = 0.0,
         *,
         finetune_text_encoder: bool = False,
@@ -99,6 +102,8 @@ class StableDiffusionXL(BaseModel):
             data_preprocessor = {"type": "SDXLDataPreprocessor"}
         if noise_generator is None:
             noise_generator = {"type": "WhiteNoise"}
+        if timesteps_generator is None:
+            timesteps_generator = {"type": "TimeSteps"}
         if loss is None:
             loss = {"type": "L2Loss", "loss_weight": 1.0}
         super().__init__(data_preprocessor=data_preprocessor)
@@ -143,6 +148,7 @@ class StableDiffusionXL(BaseModel):
         self.unet = UNet2DConditionModel.from_pretrained(
             model, subfolder="unet")
         self.noise_generator = MODELS.build(noise_generator)
+        self.timesteps_generator = MODELS.build(timesteps_generator)
         self.prepare_model()
         self.set_lora()
 
@@ -358,6 +364,7 @@ class StableDiffusionXL(BaseModel):
                                 latents: torch.Tensor,
                                 noise: torch.Tensor,
                                 timesteps: torch.Tensor) -> torch.Tensor:
+        """Preprocess model input."""
         if self.input_perturbation_gamma > 0:
             input_noise = noise + self.input_perturbation_gamma * torch.randn_like(
                 noise)
@@ -399,11 +406,8 @@ class StableDiffusionXL(BaseModel):
 
         noise = self.noise_generator(latents)
 
-        timesteps = torch.randint(
-            0,
-            self.scheduler.config.num_train_timesteps, (num_batches, ),
-            device=self.device)
-        timesteps = timesteps.long()
+        timesteps = self.timesteps_generator(self.scheduler, num_batches,
+                                            self.device)
 
         noisy_latents = self._preprocess_model_input(latents, noise, timesteps)
 

--- a/diffengine/models/editors/stable_diffusion_xl_controlnet/stable_diffusion_xl_controlnet.py
+++ b/diffengine/models/editors/stable_diffusion_xl_controlnet/stable_diffusion_xl_controlnet.py
@@ -221,11 +221,8 @@ class StableDiffusionXLControlNet(StableDiffusionXL):
 
         noise = self.noise_generator(latents)
 
-        timesteps = torch.randint(
-            0,
-            self.scheduler.config.num_train_timesteps, (num_batches, ),
-            device=self.device)
-        timesteps = timesteps.long()
+        timesteps = self.timesteps_generator(self.scheduler, num_batches,
+                                            self.device)
 
         noisy_latents = self._preprocess_model_input(latents, noise, timesteps)
 

--- a/diffengine/models/utils/__init__.py
+++ b/diffengine/models/utils/__init__.py
@@ -1,3 +1,12 @@
 from .noise import OffsetNoise, PyramidNoise, WhiteNoise
+from .timesteps import (
+    CubicSamplingTimeSteps,
+    EarlierTimeSteps,
+    LaterTimeSteps,
+    RangeTimeSteps,
+    TimeSteps,
+)
 
-__all__ = ["WhiteNoise", "OffsetNoise", "PyramidNoise"]
+__all__ = ["WhiteNoise", "OffsetNoise", "PyramidNoise",
+           "TimeSteps", "LaterTimeSteps", "EarlierTimeSteps", "RangeTimeSteps",
+           "CubicSamplingTimeSteps"]

--- a/diffengine/models/utils/timesteps.py
+++ b/diffengine/models/utils/timesteps.py
@@ -1,0 +1,202 @@
+import torch
+from diffusers import DDPMScheduler
+from torch import nn
+
+from diffengine.registry import MODELS
+
+
+@MODELS.register_module()
+class TimeSteps(nn.Module):
+    """Time Steps module."""
+
+    def forward(self, scheduler: DDPMScheduler, num_batches: int, device: str,
+                ) -> torch.Tensor:
+        """Forward pass.
+
+        Generates time steps for the given batches.
+
+        Args:
+        ----
+            scheduler (DDPMScheduler): Scheduler for training diffusion model.
+            num_batches (int): Batch size.
+            device (str): Device.
+        """
+        timesteps = torch.randint(
+            0,
+            scheduler.config.num_train_timesteps, (num_batches, ),
+            device=device)
+        return timesteps.long()
+
+
+@MODELS.register_module()
+class LaterTimeSteps(nn.Module):
+    """Later biased Time Steps module.
+
+    Args:
+    ----
+        bias_multiplier (float): Bias multiplier. Defaults to 10.
+        bias_portion (float): Portion of later time steps to bias.
+            Defaults to 0.25.
+    """
+
+    def __init__(self, bias_multiplier: float = 5., bias_portion: float = 0.25,
+                 ) -> None:
+        super().__init__()
+        lower_limit = 0.
+        upper_limit = 1.
+        assert lower_limit <= bias_portion <= upper_limit, \
+            "bias_portion must be in [0, 1]"
+
+        self.bias_multiplier = bias_multiplier
+        self.bias_portion = bias_portion
+
+    def forward(self, scheduler: DDPMScheduler, num_batches: int, device: str,
+                ) -> torch.Tensor:
+        """Forward pass.
+
+        Generates time steps for the given batches.
+
+        Args:
+        ----
+            scheduler (DDPMScheduler): Scheduler for training diffusion model.
+            num_batches (int): Batch size.
+            device (str): Device.
+        """
+        weights = torch.ones(
+            scheduler.config.num_train_timesteps, device=device)
+        num_to_bias = int(
+            self.bias_portion * scheduler.config.num_train_timesteps)
+        bias_indices = slice(-num_to_bias, None)
+        weights[bias_indices] *= self.bias_multiplier
+        weights /= weights.sum()
+
+        timesteps = torch.multinomial(weights, num_batches, replacement=True)
+        return timesteps.long()
+
+
+@MODELS.register_module()
+class EarlierTimeSteps(nn.Module):
+    """Earlier biased Time Steps module.
+
+    Args:
+    ----
+        bias_multiplier (float): Bias multiplier. Defaults to 10.
+        bias_portion (float): Portion of earlier time steps to bias.
+            Defaults to 0.25.
+    """
+
+    def __init__(self, bias_multiplier: float = 5., bias_portion: float = 0.25,
+                 ) -> None:
+        super().__init__()
+        lower_limit = 0.
+        upper_limit = 1.
+        assert lower_limit <= bias_portion <= upper_limit, \
+            "bias_portion must be in [0, 1]"
+
+        self.bias_multiplier = bias_multiplier
+        self.bias_portion = bias_portion
+
+    def forward(self, scheduler: DDPMScheduler, num_batches: int, device: str,
+                ) -> torch.Tensor:
+        """Forward pass.
+
+        Generates time steps for the given batches.
+
+        Args:
+        ----
+            scheduler (DDPMScheduler): Scheduler for training diffusion model.
+            num_batches (int): Batch size.
+            device (str): Device.
+        """
+        weights = torch.ones(
+            scheduler.config.num_train_timesteps, device=device)
+        num_to_bias = int(
+            self.bias_portion * scheduler.config.num_train_timesteps)
+        bias_indices = slice(0, num_to_bias)
+        weights[bias_indices] *= self.bias_multiplier
+        weights /= weights.sum()
+
+        timesteps = torch.multinomial(weights, num_batches, replacement=True)
+        return timesteps.long()
+
+
+@MODELS.register_module()
+class RangeTimeSteps(nn.Module):
+    """Range biased Time Steps module.
+
+    Args:
+    ----
+        bias_multiplier (float): Bias multiplier. Defaults to 10.
+        bias_begin (float): Portion of begin time steps to bias.
+            Defaults to 0.25.
+        bias_end (float): Portion of end time steps to bias.
+            Defaults to 0.75.
+    """
+
+    def __init__(self, bias_multiplier: float = 5., bias_begin: float = 0.25,
+                 bias_end: float = 0.75) -> None:
+        super().__init__()
+        lower_limit = 0.
+        upper_limit = 1.
+        assert bias_begin < bias_end, "bias_begin must be less than bias_end"
+        assert lower_limit <= bias_begin <= upper_limit, \
+            "bias_begin must be in [0, 1]"
+        assert lower_limit <= bias_end <= upper_limit, \
+            "bias_end must be in [0, 1]"
+
+        self.bias_multiplier = bias_multiplier
+        self.bias_begin = bias_begin
+        self.bias_end = bias_end
+
+    def forward(self, scheduler: DDPMScheduler, num_batches: int, device: str,
+                ) -> torch.Tensor:
+        """Forward pass.
+
+        Generates time steps for the given batches.
+
+        Args:
+        ----
+            scheduler (DDPMScheduler): Scheduler for training diffusion model.
+            num_batches (int): Batch size.
+            device (str): Device.
+        """
+        weights = torch.ones(
+            scheduler.config.num_train_timesteps, device=device)
+        bias_begin = int(
+            self.bias_begin * scheduler.config.num_train_timesteps)
+        bias_end = int(
+            self.bias_end * scheduler.config.num_train_timesteps)
+        bias_indices = slice(bias_begin, bias_end)
+        weights[bias_indices] *= self.bias_multiplier
+        weights /= weights.sum()
+
+        timesteps = torch.multinomial(weights, num_batches, replacement=True)
+        return timesteps.long()
+
+
+@MODELS.register_module()
+class CubicSamplingTimeSteps(nn.Module):
+    """Cubic Sampling Time Steps module.
+
+    For more details about why cubic sampling is used, refer to section
+    3.4 of https://arxiv.org/abs/2302.08453
+    """
+
+    def forward(self, scheduler: DDPMScheduler, num_batches: int, device: str,
+                ) -> torch.Tensor:
+        """Forward pass.
+
+        Generates time steps for the given batches.
+
+        Args:
+        ----
+            scheduler (DDPMScheduler): Scheduler for training diffusion model.
+            num_batches (int): Batch size.
+            device (str): Device.
+        """
+        timesteps = torch.rand((num_batches, ), device=device)
+        timesteps = (
+            1 - timesteps ** 3) * scheduler.config.num_train_timesteps
+        timesteps = timesteps.long()
+        return timesteps.clamp(
+            0, scheduler.config.num_train_timesteps - 1)

--- a/tests/test_engine/test_hooks/test_compile_hook.py
+++ b/tests/test_engine/test_hooks/test_compile_hook.py
@@ -13,7 +13,7 @@ from diffengine.models.editors import (
     StableDiffusionXL,
 )
 from diffengine.models.losses import L2Loss
-from diffengine.models.utils import WhiteNoise
+from diffengine.models.utils import TimeSteps, WhiteNoise
 
 
 class TestCompileHook(RunnerTestCase):
@@ -28,6 +28,7 @@ class TestCompileHook(RunnerTestCase):
             name="SDXLDataPreprocessor", module=SDXLDataPreprocessor)
         MODELS.register_module(name="L2Loss", module=L2Loss)
         MODELS.register_module(name="WhiteNoise", module=WhiteNoise)
+        MODELS.register_module(name="TimeSteps", module=TimeSteps)
         return super().setUp()
 
     def tearDown(self) -> None:
@@ -37,6 +38,7 @@ class TestCompileHook(RunnerTestCase):
         MODELS.module_dict.pop("SDXLDataPreprocessor")
         MODELS.module_dict.pop("L2Loss")
         MODELS.module_dict.pop("WhiteNoise")
+        MODELS.module_dict.pop("TimeSteps")
         return super().tearDown()
 
     def test_init(self) -> None:

--- a/tests/test_engine/test_hooks/test_controlnet_save_hook.py
+++ b/tests/test_engine/test_hooks/test_controlnet_save_hook.py
@@ -14,7 +14,7 @@ from diffengine.models.editors import (
     StableDiffusionControlNet,
 )
 from diffengine.models.losses import L2Loss
-from diffengine.models.utils import WhiteNoise
+from diffengine.models.utils import TimeSteps, WhiteNoise
 
 
 class DummyWrapper(BaseModel):
@@ -40,6 +40,7 @@ class TestLoRASaveHook(RunnerTestCase):
             module=SDControlNetDataPreprocessor)
         MODELS.register_module(name="L2Loss", module=L2Loss)
         MODELS.register_module(name="WhiteNoise", module=WhiteNoise)
+        MODELS.register_module(name="TimeSteps", module=TimeSteps)
         return super().setUp()
 
     def tearDown(self):
@@ -48,6 +49,7 @@ class TestLoRASaveHook(RunnerTestCase):
         MODELS.module_dict.pop("SDControlNetDataPreprocessor")
         MODELS.module_dict.pop("L2Loss")
         MODELS.module_dict.pop("WhiteNoise")
+        MODELS.module_dict.pop("TimeSteps")
         return super().tearDown()
 
     def test_init(self):

--- a/tests/test_engine/test_hooks/test_fast_norm_hook.py
+++ b/tests/test_engine/test_hooks/test_fast_norm_hook.py
@@ -15,7 +15,7 @@ from diffengine.models.editors import (
     StableDiffusionXLControlNet,
 )
 from diffengine.models.losses import L2Loss
-from diffengine.models.utils import WhiteNoise
+from diffengine.models.utils import TimeSteps, WhiteNoise
 
 try:
     import apex
@@ -41,6 +41,7 @@ class TestFastNormHook(RunnerTestCase):
             module=SDXLControlNetDataPreprocessor)
         MODELS.register_module(name="L2Loss", module=L2Loss)
         MODELS.register_module(name="WhiteNoise", module=WhiteNoise)
+        MODELS.register_module(name="TimeSteps", module=TimeSteps)
         return super().setUp()
 
     def tearDown(self) -> None:
@@ -52,6 +53,7 @@ class TestFastNormHook(RunnerTestCase):
         MODELS.module_dict.pop("SDXLControlNetDataPreprocessor")
         MODELS.module_dict.pop("L2Loss")
         MODELS.module_dict.pop("WhiteNoise")
+        MODELS.module_dict.pop("TimeSteps")
         return super().tearDown()
 
     @unittest.skipIf(apex is None, "apex is not installed")

--- a/tests/test_engine/test_hooks/test_ip_adapter_save_hook.py
+++ b/tests/test_engine/test_hooks/test_ip_adapter_save_hook.py
@@ -11,7 +11,7 @@ from torch import nn
 from diffengine.engine.hooks import IPAdapterSaveHook
 from diffengine.models.editors import IPAdapterXL, IPAdapterXLDataPreprocessor
 from diffengine.models.losses import L2Loss
-from diffengine.models.utils import WhiteNoise
+from diffengine.models.utils import TimeSteps, WhiteNoise
 
 
 class DummyWrapper(BaseModel):
@@ -36,6 +36,7 @@ class TestLoRASaveHook(RunnerTestCase):
             module=IPAdapterXLDataPreprocessor)
         MODELS.register_module(name="L2Loss", module=L2Loss)
         MODELS.register_module(name="WhiteNoise", module=WhiteNoise)
+        MODELS.register_module(name="TimeSteps", module=TimeSteps)
         return super().setUp()
 
     def tearDown(self):
@@ -44,6 +45,7 @@ class TestLoRASaveHook(RunnerTestCase):
         MODELS.module_dict.pop("IPAdapterXLDataPreprocessor")
         MODELS.module_dict.pop("L2Loss")
         MODELS.module_dict.pop("WhiteNoise")
+        MODELS.module_dict.pop("TimeSteps")
         return super().tearDown()
 
     def test_init(self):

--- a/tests/test_engine/test_hooks/test_lora_save_hook.py
+++ b/tests/test_engine/test_hooks/test_lora_save_hook.py
@@ -16,7 +16,7 @@ from diffengine.models.editors import (
     StableDiffusionXL,
 )
 from diffengine.models.losses import L2Loss
-from diffengine.models.utils import WhiteNoise
+from diffengine.models.utils import TimeSteps, WhiteNoise
 
 
 class DummyWrapper(BaseModel):
@@ -44,6 +44,7 @@ class TestLoRASaveHook(RunnerTestCase):
             name="SDXLDataPreprocessor", module=SDXLDataPreprocessor)
         MODELS.register_module(name="L2Loss", module=L2Loss)
         MODELS.register_module(name="WhiteNoise", module=WhiteNoise)
+        MODELS.register_module(name="TimeSteps", module=TimeSteps)
         return super().setUp()
 
     def tearDown(self):
@@ -54,6 +55,7 @@ class TestLoRASaveHook(RunnerTestCase):
         MODELS.module_dict.pop("SDXLDataPreprocessor")
         MODELS.module_dict.pop("L2Loss")
         MODELS.module_dict.pop("WhiteNoise")
+        MODELS.module_dict.pop("TimeSteps")
         return super().tearDown()
 
     def test_init(self):

--- a/tests/test_engine/test_hooks/test_t2i_adapter_save_hook.py
+++ b/tests/test_engine/test_hooks/test_t2i_adapter_save_hook.py
@@ -14,7 +14,7 @@ from diffengine.models.editors import (
     StableDiffusionXLT2IAdapter,
 )
 from diffengine.models.losses import L2Loss
-from diffengine.models.utils import WhiteNoise
+from diffengine.models.utils import TimeSteps, WhiteNoise
 
 
 class DummyWrapper(BaseModel):
@@ -41,6 +41,7 @@ class TestLoRASaveHook(RunnerTestCase):
             module=SDXLControlNetDataPreprocessor)
         MODELS.register_module(name="L2Loss", module=L2Loss)
         MODELS.register_module(name="WhiteNoise", module=WhiteNoise)
+        MODELS.register_module(name="TimeSteps", module=TimeSteps)
         return super().setUp()
 
     def tearDown(self):
@@ -49,6 +50,7 @@ class TestLoRASaveHook(RunnerTestCase):
         MODELS.module_dict.pop("SDXLControlNetDataPreprocessor")
         MODELS.module_dict.pop("L2Loss")
         MODELS.module_dict.pop("WhiteNoise")
+        MODELS.module_dict.pop("TimeSteps")
         return super().tearDown()
 
     def test_init(self):

--- a/tests/test_engine/test_hooks/test_t2i_adapter_save_hook.py
+++ b/tests/test_engine/test_hooks/test_t2i_adapter_save_hook.py
@@ -14,7 +14,7 @@ from diffengine.models.editors import (
     StableDiffusionXLT2IAdapter,
 )
 from diffengine.models.losses import L2Loss
-from diffengine.models.utils import TimeSteps, WhiteNoise
+from diffengine.models.utils import CubicSamplingTimeSteps, WhiteNoise
 
 
 class DummyWrapper(BaseModel):
@@ -41,7 +41,8 @@ class TestLoRASaveHook(RunnerTestCase):
             module=SDXLControlNetDataPreprocessor)
         MODELS.register_module(name="L2Loss", module=L2Loss)
         MODELS.register_module(name="WhiteNoise", module=WhiteNoise)
-        MODELS.register_module(name="TimeSteps", module=TimeSteps)
+        MODELS.register_module(name="CubicSamplingTimeSteps",
+                               module=CubicSamplingTimeSteps)
         return super().setUp()
 
     def tearDown(self):
@@ -50,7 +51,7 @@ class TestLoRASaveHook(RunnerTestCase):
         MODELS.module_dict.pop("SDXLControlNetDataPreprocessor")
         MODELS.module_dict.pop("L2Loss")
         MODELS.module_dict.pop("WhiteNoise")
-        MODELS.module_dict.pop("TimeSteps")
+        MODELS.module_dict.pop("CubicSamplingTimeSteps")
         return super().tearDown()
 
     def test_init(self):

--- a/tests/test_engine/test_hooks/test_visualization_hook.py
+++ b/tests/test_engine/test_hooks/test_visualization_hook.py
@@ -13,7 +13,7 @@ from diffengine.models.editors import (
     StableDiffusionControlNet,
 )
 from diffengine.models.losses import L2Loss
-from diffengine.models.utils import WhiteNoise
+from diffengine.models.utils import TimeSteps, WhiteNoise
 
 
 class TestVisualizationHook(RunnerTestCase):
@@ -29,6 +29,7 @@ class TestVisualizationHook(RunnerTestCase):
             module=SDControlNetDataPreprocessor)
         MODELS.register_module(name="L2Loss", module=L2Loss)
         MODELS.register_module(name="WhiteNoise", module=WhiteNoise)
+        MODELS.register_module(name="TimeSteps", module=TimeSteps)
         return super().setUp()
 
     def tearDown(self):
@@ -38,6 +39,7 @@ class TestVisualizationHook(RunnerTestCase):
         MODELS.module_dict.pop("SDControlNetDataPreprocessor")
         MODELS.module_dict.pop("L2Loss")
         MODELS.module_dict.pop("WhiteNoise")
+        MODELS.module_dict.pop("TimeSteps")
         return super().tearDown()
 
     def test_after_train_epoch(self):

--- a/tests/test_models/test_editors/test_t2i_adapter/test_stable_diffusion_xl_t2i_adapter.py
+++ b/tests/test_models/test_editors/test_t2i_adapter/test_stable_diffusion_xl_t2i_adapter.py
@@ -11,6 +11,7 @@ from diffengine.models.editors import (
     StableDiffusionXLT2IAdapter,
 )
 from diffengine.models.losses import L2Loss
+from diffengine.models.utils import CubicSamplingTimeSteps
 
 
 class TestStableDiffusionXLT2IAdapter(TestCase):
@@ -37,6 +38,7 @@ class TestStableDiffusionXLT2IAdapter(TestCase):
             adapter_model="hf-internal-testing/tiny-adapter",
             data_preprocessor=SDXLControlNetDataPreprocessor())
         assert isinstance(StableDiffuser.adapter, T2IAdapter)
+        assert isinstance(StableDiffuser.timesteps_generator, CubicSamplingTimeSteps)
 
         # test infer
         result = StableDiffuser.infer(

--- a/tests/test_models/test_utils/test_timesteps.py
+++ b/tests/test_models/test_utils/test_timesteps.py
@@ -1,0 +1,123 @@
+from unittest import TestCase
+
+import pytest
+from diffusers import DDPMScheduler
+
+from diffengine.models.utils import (
+    CubicSamplingTimeSteps,
+    EarlierTimeSteps,
+    LaterTimeSteps,
+    RangeTimeSteps,
+    TimeSteps,
+)
+
+
+class TestTimeSteps(TestCase):
+
+    def test_init(self):
+        _ = TimeSteps()
+
+    def test_forward(self):
+        module = TimeSteps()
+        scheduler = DDPMScheduler.from_pretrained(
+            "runwayml/stable-diffusion-v1-5", subfolder="scheduler")
+        batch_size = 2
+        timesteps = module(scheduler, batch_size, "cpu")
+        assert timesteps.shape == (2,)
+
+
+class TestCubicSamplingTimeSteps(TestCase):
+
+    def test_init(self):
+        _ = CubicSamplingTimeSteps()
+
+    def test_forward(self):
+        module = CubicSamplingTimeSteps()
+        scheduler = DDPMScheduler.from_pretrained(
+            "runwayml/stable-diffusion-v1-5", subfolder="scheduler")
+        batch_size = 2
+        timesteps = module(scheduler, batch_size, "cpu")
+        assert timesteps.shape == (2,)
+
+
+class TestLaterTimeSteps(TestCase):
+
+    def test_init(self):
+        module = LaterTimeSteps()
+        assert module.bias_multiplier == 5.
+        assert module.bias_portion == 0.25
+
+        module = LaterTimeSteps(bias_multiplier=10., bias_portion=0.5)
+        assert module.bias_multiplier == 10.
+        assert module.bias_portion == 0.5
+
+        with pytest.raises(
+                AssertionError, match="bias_portion must be in"):
+            _ = LaterTimeSteps(bias_portion=1.1)
+
+    def test_forward(self):
+        module = LaterTimeSteps()
+        scheduler = DDPMScheduler.from_pretrained(
+            "runwayml/stable-diffusion-v1-5", subfolder="scheduler")
+        batch_size = 2
+        timesteps = module(scheduler, batch_size, "cpu")
+        assert timesteps.shape == (2,)
+
+
+class TestEarlierTimeSteps(TestCase):
+
+    def test_init(self):
+        module = EarlierTimeSteps()
+        assert module.bias_multiplier == 5.
+        assert module.bias_portion == 0.25
+
+        module = EarlierTimeSteps(bias_multiplier=10., bias_portion=0.5)
+        assert module.bias_multiplier == 10.
+        assert module.bias_portion == 0.5
+
+        with pytest.raises(
+                AssertionError, match="bias_portion must be in"):
+            _ = EarlierTimeSteps(bias_portion=1.1)
+
+    def test_forward(self):
+        module = EarlierTimeSteps()
+        scheduler = DDPMScheduler.from_pretrained(
+            "runwayml/stable-diffusion-v1-5", subfolder="scheduler")
+        batch_size = 2
+        timesteps = module(scheduler, batch_size, "cpu")
+        assert timesteps.shape == (2,)
+
+
+class TestRangeTimeSteps(TestCase):
+
+    def test_init(self):
+        module = RangeTimeSteps()
+        assert module.bias_multiplier == 5.
+        assert module.bias_begin == 0.25
+        assert module.bias_end == 0.75
+
+        module = RangeTimeSteps(bias_multiplier=10., bias_begin=0.5,
+                                bias_end=1.0)
+        assert module.bias_multiplier == 10.
+        assert module.bias_begin == 0.5
+        assert module.bias_end == 1.0
+
+        with pytest.raises(
+                AssertionError, match="bias_begin must be in"):
+            _ = RangeTimeSteps(bias_begin=-1)
+
+        with pytest.raises(
+                AssertionError, match="bias_end must be in"):
+            _ = RangeTimeSteps(bias_end=1.1)
+
+        with pytest.raises(
+                AssertionError, match="bias_begin must be less than bias_end"):
+            _ = RangeTimeSteps(bias_begin=1, bias_end=0)
+
+    def test_forward(self):
+        module = RangeTimeSteps()
+        scheduler = DDPMScheduler.from_pretrained(
+            "runwayml/stable-diffusion-v1-5", subfolder="scheduler")
+        batch_size = 2
+        timesteps = module(scheduler, batch_size, "cpu")
+        assert timesteps.shape == (2,)


### PR DESCRIPTION
## Motivation

[Time Steps Bias](https://github.com/huggingface/diffusers/pull/5094)

## Results (Optional)

#### stable_diffusion_xl_pokemon_blip_later_bias

![example1](https://github.com/okotaku/diffengine/assets/24734142/99f2139d-84f4-4658-8eb2-377216de2b0d)

#### stable_diffusion_xl_pokemon_blip_earlier_bias

![example2](https://github.com/okotaku/diffengine/assets/24734142/4a353bcd-44f3-4066-a095-09696cb09d6f)

#### stable_diffusion_xl_pokemon_blip_range_bias

![example3](https://github.com/okotaku/diffengine/assets/24734142/13b9b041-9103-4f04-8e19-569d59a55bcf)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.


<!-- readthedocs-preview DiffEngine start -->
----
:books: Documentation preview :books:: https://DiffEngine--90.org.readthedocs.build/en/90/

<!-- readthedocs-preview DiffEngine end -->