### PR TITLE
[Feature] Supoport Instruction-tuning SDXL

### DIFF
--- a/configs/_base_/datasets/cartoonization_xl.py
+++ b/configs/_base_/datasets/cartoonization_xl.py
@@ -1,0 +1,48 @@
+train_pipeline = [
+    dict(type="SaveImageShape"),
+    dict(
+        type="torchvision/Resize",
+        size=768,
+        interpolation="bilinear",
+        keys=["img", "condition_img"]),
+    dict(type="RandomCrop", size=768, keys=["img", "condition_img"],
+         force_same_size=False),
+    dict(type="RandomHorizontalFlip", p=0.5, keys=["img", "condition_img"]),
+    dict(type="ComputeTimeIds"),
+    dict(type="torchvision/ToTensor", keys=["img", "condition_img"]),
+    dict(type="DumpImage", max_imgs=10, dump_dir="work_dirs/dump"),
+    dict(type="torchvision/Normalize", mean=[0.5], std=[0.5],
+        keys=["img", "condition_img"]),
+    dict(
+        type="PackInputs",
+        input_keys=["img", "condition_img", "text", "time_ids"]),
+]
+train_dataloader = dict(
+    batch_size=1,
+    num_workers=4,
+    dataset=dict(
+        type="HFControlNetDataset",
+        dataset="instruction-tuning-sd/cartoonization",
+        image_column="cartoonized_image",
+        condition_column="original_image",
+        caption_column="edit_prompt",
+        pipeline=train_pipeline),
+    sampler=dict(type="DefaultSampler", shuffle=True),
+)
+
+val_dataloader = None
+val_evaluator = None
+test_dataloader = val_dataloader
+test_evaluator = val_evaluator
+
+custom_hooks = [
+    dict(
+        type="VisualizationHook",
+        prompt=["Generate a cartoonized version of the natural image"] * 4,
+        condition_image=[
+            'https://hf.co/datasets/diffusers/diffusers-images-docs/resolve/main/mountain.png'  # noqa
+        ] * 4,
+        height=768,
+        width=768),
+    dict(type="SDCheckpointHook"),
+]

--- a/configs/_base_/datasets/low_level_image_process_xl.py
+++ b/configs/_base_/datasets/low_level_image_process_xl.py
@@ -1,0 +1,48 @@
+train_pipeline = [
+    dict(type="SaveImageShape"),
+    dict(
+        type="torchvision/Resize",
+        size=768,
+        interpolation="bilinear",
+        keys=["img", "condition_img"]),
+    dict(type="RandomCrop", size=768, keys=["img", "condition_img"],
+         force_same_size=False),
+    dict(type="RandomHorizontalFlip", p=0.5, keys=["img", "condition_img"]),
+    dict(type="ComputeTimeIds"),
+    dict(type="torchvision/ToTensor", keys=["img", "condition_img"]),
+    dict(type="DumpImage", max_imgs=10, dump_dir="work_dirs/dump"),
+    dict(type="torchvision/Normalize", mean=[0.5], std=[0.5],
+        keys=["img", "condition_img"]),
+    dict(
+        type="PackInputs",
+        input_keys=["img", "condition_img", "text", "time_ids"]),
+]
+train_dataloader = dict(
+    batch_size=1,
+    num_workers=4,
+    dataset=dict(
+        type="HFControlNetDataset",
+        dataset="instruction-tuning-sd/low-level-image-proc",
+        image_column="ground_truth_image",
+        condition_column="input_image",
+        caption_column="instruction",
+        pipeline=train_pipeline),
+    sampler=dict(type="DefaultSampler", shuffle=True),
+)
+
+val_dataloader = None
+val_evaluator = None
+test_dataloader = val_dataloader
+test_evaluator = val_evaluator
+
+custom_hooks = [
+    dict(
+        type="VisualizationHook",
+        prompt=["Derain the image"] * 4,
+        condition_image=[
+            'https://huggingface.co/datasets/sayakpaul/sample-datasets/resolve/main/derain_the_image_1.png'  # noqa
+        ] * 4,
+        height=768,
+        width=768),
+    dict(type="SDCheckpointHook"),
+]

--- a/configs/instruct_pix2pix/README.md
+++ b/configs/instruct_pix2pix/README.md
@@ -86,3 +86,19 @@ image.save('demo.png')
 ![input1](https://huggingface.co/datasets/diffusers/diffusers-images-docs/resolve/main/mountain.png)
 
 ![example1](https://github.com/okotaku/diffengine/assets/24734142/f66149fd-e375-4f85-bfbf-d4d046cd469a)
+
+#### stable_diffusion_xl_cartoonization
+
+![input2](https://hf.co/datasets/diffusers/diffusers-images-docs/resolve/main/mountain.png)
+
+![example2](https://github.com/okotaku/diffengine/assets/24734142/1206a53c-c3f7-40a3-9f48-6d01ae176a36)
+
+#### stable_diffusion_xl_low_level_image_process
+
+![input3](https://huggingface.co/datasets/sayakpaul/sample-datasets/resolve/main/derain_the_image_1.png)
+
+![example3](https://github.com/okotaku/diffengine/assets/24734142/55fb5c32-b77c-4667-bf81-3b7c7eb9f8a1)
+
+## Acknowledgement
+
+Some experiments are based on [Instruction-tuning Stable Diffusion with InstructPix2Pix](https://huggingface.co/blog/instruction-tuning-sd). Thank you for the great blog post.

--- a/configs/instruct_pix2pix/stable_diffusion_xl_cartoonization.py
+++ b/configs/instruct_pix2pix/stable_diffusion_xl_cartoonization.py
@@ -1,0 +1,20 @@
+_base_ = [
+    "../_base_/models/stable_diffusion_xl_instruct_pix2pix.py",
+    "../_base_/datasets/cartoonization_xl.py",
+    "../_base_/schedules/stable_diffusion_3e.py",
+    "../_base_/default_runtime.py",
+]
+
+model = dict(model="diffusers/sdxl-instructpix2pix-768")
+
+optim_wrapper = dict(
+    optimizer=dict(
+        _delete_=True,
+        type="Adafactor",
+        lr=3e-5,
+        weight_decay=1e-2,
+        scale_parameter=False,
+        relative_step=False),
+    accumulative_counts=4)
+
+train_cfg = dict(max_epochs=10)

--- a/configs/instruct_pix2pix/stable_diffusion_xl_low_level_image_process.py
+++ b/configs/instruct_pix2pix/stable_diffusion_xl_low_level_image_process.py
@@ -1,0 +1,20 @@
+_base_ = [
+    "../_base_/models/stable_diffusion_xl_instruct_pix2pix.py",
+    "../_base_/datasets/low_level_image_process_xl.py",
+    "../_base_/schedules/stable_diffusion_3e.py",
+    "../_base_/default_runtime.py",
+]
+
+model = dict(model="diffusers/sdxl-instructpix2pix-768")
+
+optim_wrapper = dict(
+    optimizer=dict(
+        _delete_=True,
+        type="Adafactor",
+        lr=3e-5,
+        weight_decay=1e-2,
+        scale_parameter=False,
+        relative_step=False),
+    accumulative_counts=4)
+
+train_cfg = dict(max_epochs=10)

--- a/diffengine/models/editors/instruct_pix2pix/instruct_pix2pix_xl.py
+++ b/diffengine/models/editors/instruct_pix2pix/instruct_pix2pix_xl.py
@@ -77,17 +77,18 @@ class StableDiffusionXLInstructPix2Pix(StableDiffusionXL):
         """
         # Fix input channels of Unet
         in_channels = 8
-        out_channels = self.unet.conv_in.out_channels
-        self.unet.register_to_config(in_channels=in_channels)
+        if self.unet.in_channels != in_channels:
+            out_channels = self.unet.conv_in.out_channels
+            self.unet.register_to_config(in_channels=in_channels)
 
-        with torch.no_grad():
-            new_conv_in = nn.Conv2d(
-                in_channels, out_channels, self.unet.conv_in.kernel_size,
-                self.unet.conv_in.stride, self.unet.conv_in.padding,
-            )
-            new_conv_in.weight.zero_()
-            new_conv_in.weight[:, :4, :, :].copy_(self.unet.conv_in.weight)
-            self.unet.conv_in = new_conv_in
+            with torch.no_grad():
+                new_conv_in = nn.Conv2d(
+                    in_channels, out_channels, self.unet.conv_in.kernel_size,
+                    self.unet.conv_in.stride, self.unet.conv_in.padding,
+                )
+                new_conv_in.weight.zero_()
+                new_conv_in.weight[:, :4, :, :].copy_(self.unet.conv_in.weight)
+                self.unet.conv_in = new_conv_in
 
         super().prepare_model()
 


### PR DESCRIPTION
## Motivation

[Instruction-tuning Stable Diffusion with InstructPix2Pix](https://huggingface.co/blog/instruction-tuning-sd)

## Results (Optional)

#### stable_diffusion_xl_cartoonization

![input2](https://hf.co/datasets/diffusers/diffusers-images-docs/resolve/main/mountain.png)

![example2](https://github.com/okotaku/diffengine/assets/24734142/1206a53c-c3f7-40a3-9f48-6d01ae176a36)

#### stable_diffusion_xl_low_level_image_process

![input3](https://huggingface.co/datasets/sayakpaul/sample-datasets/resolve/main/derain_the_image_1.png)

![example3](https://github.com/okotaku/diffengine/assets/24734142/55fb5c32-b77c-4667-bf81-3b7c7eb9f8a1)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.


<!-- readthedocs-preview DiffEngine start -->
----
:books: Documentation preview :books:: https://DiffEngine--103.org.readthedocs.build/en/103/

<!-- readthedocs-preview DiffEngine end -->