### PR TITLE
[Fix] LoRA default alpha

### DIFF
--- a/configs/_base_/models/deepfloyd_if_xl_lora.py
+++ b/configs/_base_/models/deepfloyd_if_xl_lora.py
@@ -4,6 +4,6 @@ model = dict(
     unet_lora_config=dict(
         type="LoRA",
         r=8,
-        lora_alpha=1,
+        lora_alpha=8,
         target_modules=["to_q", "to_v", "to_k", "to_out.0"]),
     gradient_checkpointing=True)

--- a/configs/_base_/models/lcm_xl_lora.py
+++ b/configs/_base_/models/lcm_xl_lora.py
@@ -8,7 +8,7 @@ model = dict(
     unet_lora_config=dict(
         type="LoRA",
         r=8,
-        lora_alpha=1,
+        lora_alpha=8,
         target_modules=[
             "to_q",
             "to_k",

--- a/configs/_base_/models/small_sd_lora.py
+++ b/configs/_base_/models/small_sd_lora.py
@@ -4,5 +4,5 @@ model = dict(
     unet_lora_config=dict(
         type="LoRA",
         r=8,
-        lora_alpha=1,
+        lora_alpha=8,
         target_modules=["to_q", "to_v", "to_k", "to_out.0"]))

--- a/configs/_base_/models/ssd_1b_lora.py
+++ b/configs/_base_/models/ssd_1b_lora.py
@@ -5,5 +5,5 @@ model = dict(
     unet_lora_config=dict(
         type="LoRA",
         r=8,
-        lora_alpha=1,
+        lora_alpha=8,
         target_modules=["to_q", "to_v", "to_k", "to_out.0"]))

--- a/configs/_base_/models/stable_diffusion_v15_lora.py
+++ b/configs/_base_/models/stable_diffusion_v15_lora.py
@@ -4,5 +4,5 @@ model = dict(
     unet_lora_config=dict(
         type="LoRA",
         r=8,
-        lora_alpha=1,
+        lora_alpha=8,
         target_modules=["to_q", "to_v", "to_k", "to_out.0"]))

--- a/configs/_base_/models/stable_diffusion_v21_lora.py
+++ b/configs/_base_/models/stable_diffusion_v21_lora.py
@@ -4,5 +4,5 @@ model = dict(
     unet_lora_config=dict(
         type="LoRA",
         r=8,
-        lora_alpha=1,
+        lora_alpha=8,
         target_modules=["to_q", "to_v", "to_k", "to_out.0"]))

--- a/configs/_base_/models/stable_diffusion_xl_loha.py
+++ b/configs/_base_/models/stable_diffusion_xl_loha.py
@@ -5,5 +5,5 @@ model = dict(
     unet_lora_config=dict(
         type="LoHa",
         r=8,
-        alpha=1,
+        alpha=8,
         target_modules=["to_q", "to_v", "to_k", "to_out.0"]))

--- a/configs/_base_/models/stable_diffusion_xl_lokr.py
+++ b/configs/_base_/models/stable_diffusion_xl_lokr.py
@@ -5,5 +5,5 @@ model = dict(
     unet_lora_config=dict(
         type="LoKr",
         r=8,
-        alpha=1,
+        alpha=8,
         target_modules=["to_q", "to_v", "to_k", "to_out.0"]))

--- a/configs/_base_/models/stable_diffusion_xl_lora.py
+++ b/configs/_base_/models/stable_diffusion_xl_lora.py
@@ -5,5 +5,5 @@ model = dict(
     unet_lora_config=dict(
         type="LoRA",
         r=8,
-        lora_alpha=1,
+        lora_alpha=8,
         target_modules=["to_q", "to_v", "to_k", "to_out.0"]))

--- a/configs/_base_/models/tiny_sd_lora.py
+++ b/configs/_base_/models/tiny_sd_lora.py
@@ -4,5 +4,5 @@ model = dict(
     unet_lora_config=dict(
         type="LoRA",
         r=8,
-        lora_alpha=1,
+        lora_alpha=8,
         target_modules=["to_q", "to_v", "to_k", "to_out.0"]))

--- a/configs/_base_/models/wuerstchen_prior_lora.py
+++ b/configs/_base_/models/wuerstchen_prior_lora.py
@@ -5,5 +5,5 @@ model = dict(
     prior_lora_config=dict(
         type="LoRA",
         r=8,
-        lora_alpha=1,
+        lora_alpha=8,
         target_modules=["to_q", "to_v", "to_k", "to_out.0"]))


### PR DESCRIPTION
## Motivation

I had a wrong understanding of the relationship between `alpha` and `scaling` in peft and have corrected it. `alpha` must be the same value as `r` in order to match diffusers.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.


<!-- readthedocs-preview DiffEngine start -->
----
:books: Documentation preview :books:: https://DiffEngine--104.org.readthedocs.build/en/104/

<!-- readthedocs-preview DiffEngine end -->