### PR TITLE
[Feature] Support PixArt Alpha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           pip install setuptools
       - name: Build and install
-        run: rm -rf .eggs && pip install -e .[dev]
+        run: rm -rf .eggs && pip install -e .[dev,optional]
       - name: Install diffusers from main branch
         run: pip install git+https://github.com/huggingface/diffusers.git
       - name: Run unittests and generate coverage report

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ For detailed user guides and advanced guides, please refer to our [Documentation
 - [Run Wuerstchen LoRA](https://diffengine.readthedocs.io/en/latest/run_guides/run_wuerstchen_lora.html)
 - [Run LCM XL](https://diffengine.readthedocs.io/en/latest/run_guides/run_lcm.html)
 - [Run LCM XL LoRA](https://diffengine.readthedocs.io/en/latest/run_guides/run_lcm_lora.html)
+- [Run PixArt-α](https://diffengine.readthedocs.io/en/latest/run_guides/run_pixart_alpha.html)
+- [Run PixArt-α LoRA](https://diffengine.readthedocs.io/en/latest/run_guides/run_pixart_alpha_lora.html)
+- [Run PixArt-α DreamBooth](https://diffengine.readthedocs.io/en/latest/run_guides/run_pixart_alpha_dreambooth.html)
 - [Inference](https://diffengine.readthedocs.io/en/latest/run_guides/inference.html)
 
 </details>
@@ -238,6 +241,9 @@ For detailed user guides and advanced guides, please refer to our [Documentation
       <td>
         <b>Latent Consistency Models</b>
       </td>
+      <td>
+        <b>PixArt-α</b>
+      </td>
     </tr>
     <tr valign="top">
       <td>
@@ -250,6 +256,13 @@ For detailed user guides and advanced guides, please refer to our [Documentation
         <ul>
             <li><a href="configs/lcm/README.md">Latent Consistency Models (2023)</a></li>
             <li><a href="configs/lcm_lora/README.md">LoRA (ICLR'2022)</a></li>
+      </ul>
+      </td>
+      <td>
+        <ul>
+            <li><a href="configs/pixart_alpha/README.md">PixArt-α (2023)</a></li>
+            <li><a href="configs/pixart_alpha_lora/README.md">LoRA (ICLR'2022)</a></li>
+            <li><a href="configs/pixart_alpha_dreambooth/README.md">DreamBooth (CVPR'2023)</a></li>
       </ul>
       </td>
     </tr>

--- a/configs/_base_/datasets/dog_dreambooth_pixart_1024.py
+++ b/configs/_base_/datasets/dog_dreambooth_pixart_1024.py
@@ -1,0 +1,39 @@
+train_pipeline = [
+    dict(type="SaveImageShape"),
+    dict(type="torchvision/Resize", size=1024, interpolation="bilinear"),
+    dict(type="RandomCrop", size=1024),
+    dict(type="RandomHorizontalFlip", p=0.5),
+    dict(type="ComputePixArtImgInfo"),
+    dict(type="torchvision/ToTensor"),
+    dict(type="torchvision/Normalize", mean=[0.5], std=[0.5]),
+    dict(type="T5TextPreprocess"),
+    dict(type="PackInputs",
+         input_keys=["img", "text", "resolution", "aspect_ratio"]),
+]
+train_dataloader = dict(
+    batch_size=2,
+    num_workers=4,
+    dataset=dict(
+        type="HFDreamBoothDataset",
+        dataset="diffusers/dog-example",
+        instance_prompt="a photo of sks dog",
+        pipeline=train_pipeline,
+        class_prompt=None),
+    sampler=dict(type="InfiniteSampler", shuffle=True),
+)
+
+val_dataloader = None
+val_evaluator = None
+test_dataloader = val_dataloader
+test_evaluator = val_evaluator
+
+custom_hooks = [
+    dict(
+        type="VisualizationHook",
+        prompt=["A photo of sks dog in a bucket"] * 4,
+        by_epoch=False,
+        interval=100,
+        height=1024,
+        width=1024),
+    dict(type="PeftSaveHook"),
+]

--- a/configs/_base_/datasets/dog_dreambooth_pixart_512.py
+++ b/configs/_base_/datasets/dog_dreambooth_pixart_512.py
@@ -1,0 +1,39 @@
+train_pipeline = [
+    dict(type="SaveImageShape"),
+    dict(type="torchvision/Resize", size=512, interpolation="bilinear"),
+    dict(type="RandomCrop", size=512),
+    dict(type="RandomHorizontalFlip", p=0.5),
+    dict(type="ComputePixArtImgInfo"),
+    dict(type="torchvision/ToTensor"),
+    dict(type="torchvision/Normalize", mean=[0.5], std=[0.5]),
+    dict(type="T5TextPreprocess"),
+    dict(type="PackInputs",
+         input_keys=["img", "text", "resolution", "aspect_ratio"]),
+]
+train_dataloader = dict(
+    batch_size=4,
+    num_workers=4,
+    dataset=dict(
+        type="HFDreamBoothDataset",
+        dataset="diffusers/dog-example",
+        instance_prompt="a photo of sks dog",
+        pipeline=train_pipeline,
+        class_prompt=None),
+    sampler=dict(type="InfiniteSampler", shuffle=True),
+)
+
+val_dataloader = None
+val_evaluator = None
+test_dataloader = val_dataloader
+test_evaluator = val_evaluator
+
+custom_hooks = [
+    dict(
+        type="VisualizationHook",
+        prompt=["A photo of sks dog in a bucket"] * 4,
+        by_epoch=False,
+        interval=100,
+        height=512,
+        width=512),
+    dict(type="PeftSaveHook"),
+]

--- a/configs/_base_/datasets/pokemon_blip_pixart.py
+++ b/configs/_base_/datasets/pokemon_blip_pixart.py
@@ -1,0 +1,35 @@
+train_pipeline = [
+    dict(type="SaveImageShape"),
+    dict(type="torchvision/Resize", size=1024, interpolation="bilinear"),
+    dict(type="RandomCrop", size=1024),
+    dict(type="RandomHorizontalFlip", p=0.5),
+    dict(type="ComputePixArtImgInfo"),
+    dict(type="torchvision/ToTensor"),
+    dict(type="torchvision/Normalize", mean=[0.5], std=[0.5]),
+    dict(type="T5TextPreprocess"),
+    dict(type="PackInputs",
+         input_keys=["img", "text", "resolution", "aspect_ratio"]),
+]
+train_dataloader = dict(
+    batch_size=1,
+    num_workers=4,
+    dataset=dict(
+        type="HFDataset",
+        dataset="lambdalabs/pokemon-blip-captions",
+        pipeline=train_pipeline),
+    sampler=dict(type="DefaultSampler", shuffle=True),
+)
+
+val_dataloader = None
+val_evaluator = None
+test_dataloader = val_dataloader
+test_evaluator = val_evaluator
+
+custom_hooks = [
+    dict(
+        type="VisualizationHook",
+        prompt=["yoda pokemon"] * 4,
+        height=1024,
+        width=1024),
+    dict(type="PixArtCheckpointHook"),
+]

--- a/configs/_base_/datasets/pokemon_blip_pixart.py
+++ b/configs/_base_/datasets/pokemon_blip_pixart.py
@@ -11,7 +11,7 @@ train_pipeline = [
          input_keys=["img", "text", "resolution", "aspect_ratio"]),
 ]
 train_dataloader = dict(
-    batch_size=1,
+    batch_size=2,
     num_workers=4,
     dataset=dict(
         type="HFDataset",

--- a/configs/_base_/models/pixart_alpha_1024.py
+++ b/configs/_base_/models/pixart_alpha_1024.py
@@ -1,3 +1,3 @@
 model = dict(type="PixArtAlpha", model="PixArt-alpha/PixArt-XL-2-1024-MS",
-             vae_model="madebyollin/sdxl-vae-fp16-fix",
+             vae_model="stabilityai/sd-vae-ft-ema",
              gradient_checkpointing=True)

--- a/configs/_base_/models/pixart_alpha_1024.py
+++ b/configs/_base_/models/pixart_alpha_1024.py
@@ -1,0 +1,3 @@
+model = dict(type="PixArtAlpha", model="PixArt-alpha/PixArt-XL-2-1024-MS",
+             vae_model="madebyollin/sdxl-vae-fp16-fix",
+             gradient_checkpointing=True)

--- a/configs/_base_/models/pixart_alpha_1024_lora.py
+++ b/configs/_base_/models/pixart_alpha_1024_lora.py
@@ -1,0 +1,8 @@
+model = dict(type="PixArtAlpha", model="PixArt-alpha/PixArt-XL-2-1024-MS",
+             vae_model="stabilityai/sd-vae-ft-ema",
+             gradient_checkpointing=True,
+             transformer_lora_config=dict(
+                type="LoRA",
+                r=8,
+                lora_alpha=8,
+                target_modules=["to_q", "to_v", "to_k", "to_out.0"]))

--- a/configs/_base_/models/pixart_alpha_512_lora.py
+++ b/configs/_base_/models/pixart_alpha_512_lora.py
@@ -1,7 +1,7 @@
-model = dict(type="PixArtAlpha", model="PixArt-alpha/PixArt-XL-2-1024-MS",
-             vae_model="madebyollin/sdxl-vae-fp16-fix",
+model = dict(type="PixArtAlpha", model="PixArt-alpha/PixArt-XL-2-512x512",
+             vae_model="stabilityai/sd-vae-ft-ema",
              gradient_checkpointing=True,
-            unet_lora_config=dict(
+             transformer_lora_config=dict(
                 type="LoRA",
                 r=8,
                 lora_alpha=8,

--- a/configs/_base_/models/pixart_alpha_lora.py
+++ b/configs/_base_/models/pixart_alpha_lora.py
@@ -1,0 +1,8 @@
+model = dict(type="PixArtAlpha", model="PixArt-alpha/PixArt-XL-2-1024-MS",
+             vae_model="madebyollin/sdxl-vae-fp16-fix",
+             gradient_checkpointing=True,
+            unet_lora_config=dict(
+                type="LoRA",
+                r=8,
+                lora_alpha=8,
+                target_modules=["to_q", "to_v", "to_k", "to_out.0"]))

--- a/configs/pixart_alpha/README.md
+++ b/configs/pixart_alpha/README.md
@@ -87,4 +87,4 @@ You can see more details on [`docs/source/run_guides/run_pixart_alpha.md`](../..
 
 #### pixart_alpha_1024_pokemon_blip
 
-![example1](https://github.com/okotaku/diffengine/assets/24734142/5029f450-d248-4f22-8f90-6588f1d5f91e)
+![example1](https://github.com/okotaku/diffengine/assets/24734142/6b87369a-4746-4067-9a8a-5d7453fc80ce)

--- a/configs/pixart_alpha/README.md
+++ b/configs/pixart_alpha/README.md
@@ -1,0 +1,90 @@
+# PixArt-α
+
+[PixArt-α: Fast Training of Diffusion Transformer for Photorealistic Text-to-Image Synthesis](https://arxiv.org/abs/2310.00426)
+
+## Abstract
+
+The most advanced text-to-image (T2I) models require significant training costs (e.g., millions of GPU hours), seriously hindering the fundamental innovation for the AIGC community while increasing CO2 emissions. This paper introduces PIXART-α, a Transformer-based T2I diffusion model whose image generation quality is competitive with state-of-the-art image generators (e.g., Imagen, SDXL, and even Midjourney), reaching near-commercial application standards. Additionally, it supports high-resolution image synthesis up to 1024px resolution with low training cost, as shown in Figure 1 and 2. To achieve this goal, three core designs are proposed: (1) Training strategy decomposition: We devise three distinct training steps that separately optimize pixel dependency, text-image alignment, and image aesthetic quality; (2) Efficient T2I Transformer: We incorporate cross-attention modules into Diffusion Transformer (DiT) to inject text conditions and streamline the computation-intensive class-condition branch; (3) High-informative data: We emphasize the significance of concept density in text-image pairs and leverage a large Vision-Language model to auto-label dense pseudo-captions to assist text-image alignment learning. As a result, PIXART-α's training speed markedly surpasses existing large-scale T2I models, e.g., PIXART-α only takes 10.8% of Stable Diffusion v1.5's training time (675 vs. 6,250 A100 GPU days), saving nearly $300,000 ($26,000 vs. $320,000) and reducing 90% CO2 emissions. Moreover, compared with a larger SOTA model, RAPHAEL, our training cost is merely 1%. Extensive experiments demonstrate that PIXART-α excels in image quality, artistry, and semantic control. We hope PIXART-α will provide new insights to the AIGC community and startups to accelerate building their own high-quality yet low-cost generative models from scratch.
+
+<div align=center>
+<img src="https://github.com/okotaku/diffengine/assets/24734142/21a7418a-6c99-41a7-b438-fcfa967fe6f7"/>
+</div>
+
+## Citation
+
+```
+@misc{chen2023pixartalpha,
+      title={PixArt-$\alpha$: Fast Training of Diffusion Transformer for Photorealistic Text-to-Image Synthesis},
+      author={Junsong Chen and Jincheng Yu and Chongjian Ge and Lewei Yao and Enze Xie and Yue Wu and Zhongdao Wang and James Kwok and Ping Luo and Huchuan Lu and Zhenguo Li},
+      year={2023},
+      eprint={2310.00426},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+## Run Training
+
+Run Training
+
+```
+# single gpu
+$ mim train diffengine ${CONFIG_FILE}
+# multi gpus
+$ mim train diffengine ${CONFIG_FILE} --gpus 2 --launcher pytorch
+
+# Example.
+$ mim train diffengine configs/pixart_alpha/pixart_alpha_1024_pokemon_blip.py
+```
+
+## Inference with diffusers
+
+Once you have trained a model, specify the path to the saved model and utilize it for inference using the `diffusers.pipeline` module.
+
+Before inferencing, we should convert weights for diffusers format,
+
+```bash
+$ mim run diffengine publish_model2diffusers ${CONFIG_FILE} ${INPUT_FILENAME} ${OUTPUT_DIR} --save-keys ${SAVE_KEYS}
+# Example
+$ mim run diffengine publish_model2diffusers configs/pixart_alpha/pixart_alpha_1024_pokemon_blip.py work_dirs/pixart_alpha_1024_pokemon_blip/epoch_50.pth work_dirs/pixart_alpha_1024_pokemon_blip --save-keys transformer
+```
+
+Then we can run inference.
+
+```py
+from pathlib import Path
+
+import torch
+from diffusers import PixArtAlphaPipeline, AutoencoderKL, Transformer2DModel
+from peft import PeftModel
+
+checkpoint = Path('work_dirs/pixart_alpha_1024_pokemon_blip')
+prompt = 'yoda pokemon'
+
+vae = AutoencoderKL.from_pretrained(
+    'stabilityai/sd-vae-ft-ema',
+)
+transformer = Transformer2DModel.from_pretrained(checkpoint, subfolder='transformer')
+pipe = PixArtAlphaPipeline.from_pretrained(
+    "PixArt-alpha/PixArt-XL-2-1024-MS",
+    vae=vae,
+    transformer=transformer,
+    torch_dtype=torch.float32,
+).to("cuda")
+
+img = pipe(
+    prompt,
+    width=1024,
+    height=1024,
+    num_inference_steps=50,
+).images[0]
+img.save("demo.png")
+```
+
+You can see more details on [`docs/source/run_guides/run_pixart_alpha.md`](../../docs/source/run_guides/run_pixart_alpha.md#inference-with-diffusers).
+
+## Results Example
+
+#### pixart_alpha_1024_pokemon_blip
+
+![example1](https://github.com/okotaku/diffengine/assets/24734142/5029f450-d248-4f22-8f90-6588f1d5f91e)

--- a/configs/pixart_alpha/pixart_alpha_1024_pokemon_blip.py
+++ b/configs/pixart_alpha/pixart_alpha_1024_pokemon_blip.py
@@ -1,0 +1,11 @@
+_base_ = [
+    "../_base_/models/pixart_alpha_1024.py",
+    "../_base_/datasets/pokemon_blip_pixart.py",
+    "../_base_/schedules/stable_diffusion_50e.py",
+    "../_base_/default_runtime.py",
+]
+
+optim_wrapper = dict(
+    _delete_=True,
+    optimizer=dict(type="AdamW", lr=1e-5, weight_decay=3e-2),
+    clip_grad=dict(max_norm=1.0))

--- a/configs/pixart_alpha/pixart_alpha_1024_pokemon_blip.py
+++ b/configs/pixart_alpha/pixart_alpha_1024_pokemon_blip.py
@@ -6,6 +6,6 @@ _base_ = [
 ]
 
 optim_wrapper = dict(
-    _delete_=True,
-    optimizer=dict(type="AdamW", lr=1e-5, weight_decay=3e-2),
-    clip_grad=dict(max_norm=1.0))
+    dtype="bfloat16",
+    optimizer=dict(lr=2e-6, weight_decay=3e-2),
+    clip_grad=dict(max_norm=0.01))

--- a/configs/pixart_alpha_dreambooth/README.md
+++ b/configs/pixart_alpha_dreambooth/README.md
@@ -1,0 +1,82 @@
+# PixArt-α DreamBooth
+
+[DreamBooth: Fine Tuning Text-to-Image Diffusion Models for Subject-Driven Generation](https://arxiv.org/abs/2208.12242)
+[PixArt-α](https://arxiv.org/abs/2310.00426)
+
+## Abstract
+
+Large text-to-image models achieved a remarkable leap in the evolution of AI, enabling high-quality and diverse synthesis of images from a given text prompt. However, these models lack the ability to mimic the appearance of subjects in a given reference set and synthesize novel renditions of them in different contexts. In this work, we present a new approach for "personalization" of text-to-image diffusion models. Given as input just a few images of a subject, we fine-tune a pretrained text-to-image model such that it learns to bind a unique identifier with that specific subject. Once the subject is embedded in the output domain of the model, the unique identifier can be used to synthesize novel photorealistic images of the subject contextualized in different scenes. By leveraging the semantic prior embedded in the model with a new autogenous class-specific prior preservation loss, our technique enables synthesizing the subject in diverse scenes, poses, views and lighting conditions that do not appear in the reference images. We apply our technique to several previously-unassailable tasks, including subject recontextualization, text-guided view synthesis, and artistic rendering, all while preserving the subject's key features. We also provide a new dataset and evaluation protocol for this new task of subject-driven generation.
+
+<div align=center>
+<img src="https://github.com/okotaku/dethub/assets/24734142/33b1953d-ce42-4f9a-bcbc-87050cfe4f6f"/>
+</div>
+
+## Citation
+
+```
+@inproceedings{ruiz2023dreambooth,
+  title={Dreambooth: Fine tuning text-to-image diffusion models for subject-driven generation},
+  author={Ruiz, Nataniel and Li, Yuanzhen and Jampani, Varun and Pritch, Yael and Rubinstein, Michael and Aberman, Kfir},
+  booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition},
+  year={2023}
+}
+```
+
+## Run Training
+
+Run Training
+
+```
+# single gpu
+$ mim train diffengine ${CONFIG_FILE}
+# multi gpus
+$ mim train diffengine ${CONFIG_FILE} --gpus 2 --launcher pytorch
+
+# Example.
+$ mim train diffengine configs/pixart_alpha_dreambooth/pixart_alpha_1024_dreambooth_lora_dog.py
+```
+
+## Inference with diffusers
+
+Once you have trained a model, specify the path to where the model is saved, and use it for inference with the `diffusers`.
+
+```py
+from pathlib import Path
+
+import torch
+from diffusers import PixArtAlphaPipeline, AutoencoderKL
+from peft import PeftModel
+
+checkpoint = Path('work_dirs/pixart_alpha_1024_dreambooth_lora_dog/step499')
+prompt = 'A photo of sks dog in a bucket'
+
+vae = AutoencoderKL.from_pretrained(
+    'stabilityai/sd-vae-ft-ema',
+)
+pipe = PixArtAlphaPipeline.from_pretrained(
+    "PixArt-alpha/PixArt-XL-2-1024-MS",
+    vae=vae,
+    torch_dtype=torch.float32,
+).to("cuda")
+pipe.transformer = PeftModel.from_pretrained(pipe.transformer, checkpoint / "transformer", adapter_name="default")
+
+img = pipe(
+    prompt,
+    width=1024,
+    height=1024,
+    num_inference_steps=50,
+).images[0]
+img.save("demo.png")
+```
+
+You can see more details on [Run PixArt-α DreamBooth docs](../../docs/source/run_guides/run_pixart_alpha_dreambooth.md#inference-with-diffusers).
+
+## Results Example
+
+#### pixart_alpha_512_dreambooth_lora_dog
+
+![exampledog](https://github.com/okotaku/diffengine/assets/24734142/2d3b59b1-2a9b-422d-adba-347504c66be2)
+
+#### pixart_alpha_1024_dreambooth_lora_dog
+
+![exampledog2](https://github.com/okotaku/diffengine/assets/24734142/a3fc9fcd-7cd0-4dc2-997d-3a9b303c228a)

--- a/configs/pixart_alpha_dreambooth/pixart_alpha_1024_dreambooth_lora_dog.py
+++ b/configs/pixart_alpha_dreambooth/pixart_alpha_1024_dreambooth_lora_dog.py
@@ -1,0 +1,13 @@
+_base_ = [
+    "../_base_/models/pixart_alpha_1024_lora.py",
+    "../_base_/datasets/dog_dreambooth_pixart_1024.py",
+    "../_base_/schedules/stable_diffusion_500.py",
+    "../_base_/default_runtime.py",
+]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}})))
+
+optim_wrapper = dict(
+    dtype="bfloat16",
+    optimizer=dict(lr=1e-4))

--- a/configs/pixart_alpha_dreambooth/pixart_alpha_512_dreambooth_lora_dog.py
+++ b/configs/pixart_alpha_dreambooth/pixart_alpha_512_dreambooth_lora_dog.py
@@ -1,0 +1,13 @@
+_base_ = [
+    "../_base_/models/pixart_alpha_512_lora.py",
+    "../_base_/datasets/dog_dreambooth_pixart_512.py",
+    "../_base_/schedules/stable_diffusion_500.py",
+    "../_base_/default_runtime.py",
+]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}})))
+
+optim_wrapper = dict(
+    dtype="bfloat16",
+    optimizer=dict(lr=1e-4))

--- a/configs/pixart_alpha_lora/README.md
+++ b/configs/pixart_alpha_lora/README.md
@@ -1,0 +1,80 @@
+# Stable Diffusion XL LoRA
+
+[LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/abs/2106.09685)
+[PixArt-α](https://arxiv.org/abs/2310.00426)
+
+## Abstract
+
+An important paradigm of natural language processing consists of large-scale pre-training on general domain data and adaptation to particular tasks or domains. As we pre-train larger models, full fine-tuning, which retrains all model parameters, becomes less feasible. Using GPT-3 175B as an example -- deploying independent instances of fine-tuned models, each with 175B parameters, is prohibitively expensive. We propose Low-Rank Adaptation, or LoRA, which freezes the pre-trained model weights and injects trainable rank decomposition matrices into each layer of the Transformer architecture, greatly reducing the number of trainable parameters for downstream tasks. Compared to GPT-3 175B fine-tuned with Adam, LoRA can reduce the number of trainable parameters by 10,000 times and the GPU memory requirement by 3 times. LoRA performs on-par or better than fine-tuning in model quality on RoBERTa, DeBERTa, GPT-2, and GPT-3, despite having fewer trainable parameters, a higher training throughput, and, unlike adapters, no additional inference latency. We also provide an empirical investigation into rank-deficiency in language model adaptation, which sheds light on the efficacy of LoRA.
+
+<div align=center>
+<img src="https://github.com/okotaku/diffengine/assets/24734142/542189e1-e88f-4e80-9a51-de241b37d994"/>
+</div>
+
+## Citation
+
+```
+@inproceedings{
+hu2022lora,
+title={Lo{RA}: Low-Rank Adaptation of Large Language Models},
+author={Edward J Hu and Yelong Shen and Phillip Wallis and Zeyuan Allen-Zhu and Yuanzhi Li and Shean Wang and Lu Wang and Weizhu Chen},
+booktitle={International Conference on Learning Representations},
+year={2022},
+url={https://openreview.net/forum?id=nZeVKeeFYf9}
+}
+```
+
+## Run Training
+
+Run Training
+
+```
+# single gpu
+$ mim train diffengine ${CONFIG_FILE}
+# multi gpus
+$ mim train diffengine ${CONFIG_FILE} --gpus 2 --launcher pytorch
+
+# Example.
+$ mim train diffengine configs/pixart_alpha_lora/pixart_alpha_1024_lora_pokemon_blip.py
+```
+
+## Inference with diffusers
+
+Once you have trained a model, specify the path to the saved model and utilize it for inference using the `diffusers.pipeline` module.
+
+```py
+from pathlib import Path
+
+import torch
+from diffusers import PixArtAlphaPipeline, AutoencoderKL
+from peft import PeftModel
+
+checkpoint = Path('work_dirs/pixart_alpha_1024_lora_pokemon_blip/step20850')
+prompt = 'yoda pokemon'
+
+vae = AutoencoderKL.from_pretrained(
+    'stabilityai/sd-vae-ft-ema',
+)
+pipe = PixArtAlphaPipeline.from_pretrained(
+    "PixArt-alpha/PixArt-XL-2-1024-MS",
+    vae=vae,
+    torch_dtype=torch.float32,
+).to("cuda")
+pipe.transformer = PeftModel.from_pretrained(pipe.transformer, checkpoint / "transformer", adapter_name="default")
+
+img = pipe(
+    prompt,
+    width=1024,
+    height=1024,
+    num_inference_steps=50,
+).images[0]
+img.save("demo.png")
+```
+
+You can see more details on [`docs/source/run_guides/run_pixart_alpha_lora.md`](../../docs/source/run_guides/run_pixart_alpha_lora.md#inference-with-diffusers).
+
+## Results Example
+
+#### pixart_alpha_1024_lora_pokemon_blip
+
+![example1](https://github.com/okotaku/diffengine/assets/24734142/1f884a73-e734-42fe-88f2-87d3ea22672d)

--- a/configs/pixart_alpha_lora/README.md
+++ b/configs/pixart_alpha_lora/README.md
@@ -77,4 +77,4 @@ You can see more details on [`docs/source/run_guides/run_pixart_alpha_lora.md`](
 
 #### pixart_alpha_1024_lora_pokemon_blip
 
-![example1](https://github.com/okotaku/diffengine/assets/24734142/1f884a73-e734-42fe-88f2-87d3ea22672d)
+![example1](https://github.com/okotaku/diffengine/assets/24734142/33f9c774-7896-4032-a11b-b86f4334de0a)

--- a/configs/pixart_alpha_lora/pixart_alpha_1024_lora_pokemon_blip.py
+++ b/configs/pixart_alpha_lora/pixart_alpha_1024_lora_pokemon_blip.py
@@ -1,6 +1,6 @@
 _base_ = [
     "../_base_/models/pixart_alpha_1024_lora.py",
-    "../_base_/datasets/pokemon_blip_pixart_lora.py",
+    "../_base_/datasets/pokemon_blip_pixart.py",
     "../_base_/schedules/stable_diffusion_50e.py",
     "../_base_/default_runtime.py",
 ]

--- a/configs/pixart_alpha_lora/pixart_alpha_1024_pokemon_blip.py
+++ b/configs/pixart_alpha_lora/pixart_alpha_1024_pokemon_blip.py
@@ -1,14 +1,12 @@
 _base_ = [
-    "../_base_/models/pixart_alpha_1024.py",
+    "../_base_/models/pixart_alpha_1024_lora.py",
     "../_base_/datasets/pokemon_blip_pixart_lora.py",
     "../_base_/schedules/stable_diffusion_50e.py",
     "../_base_/default_runtime.py",
 ]
 
 optim_wrapper = dict(
-    _delete_=True,
-    optimizer=dict(type="AdamW", lr=1e-4, weight_decay=3e-2),
-    clip_grad=dict(max_norm=1.0))
+    dtype="bfloat16")
 
 custom_hooks = [
     dict(

--- a/configs/pixart_alpha_lora/pixart_alpha_1024_pokemon_blip.py
+++ b/configs/pixart_alpha_lora/pixart_alpha_1024_pokemon_blip.py
@@ -1,0 +1,20 @@
+_base_ = [
+    "../_base_/models/pixart_alpha_1024.py",
+    "../_base_/datasets/pokemon_blip_pixart_lora.py",
+    "../_base_/schedules/stable_diffusion_50e.py",
+    "../_base_/default_runtime.py",
+]
+
+optim_wrapper = dict(
+    _delete_=True,
+    optimizer=dict(type="AdamW", lr=1e-4, weight_decay=3e-2),
+    clip_grad=dict(max_norm=1.0))
+
+custom_hooks = [
+    dict(
+        type="VisualizationHook",
+        prompt=["yoda pokemon"] * 4,
+        height=1024,
+        width=1024),
+    dict(type="PeftSaveHook"),
+]

--- a/configs/stable_diffusion_xl/stable_diffusion_xl_pokemon_blip_fast.py
+++ b/configs/stable_diffusion_xl/stable_diffusion_xl_pokemon_blip_fast.py
@@ -25,6 +25,6 @@ custom_hooks = [
         height=1024,
         width=1024),
     dict(type="SDCheckpointHook"),
-    dict(type="FastNormHook", fuse_unet_ln=False, fuse_gn=False),
-    dict(type="CompileHook", compile_unet=True),
+    dict(type="FastNormHook", fuse_main_ln=False, fuse_gn=False),
+    dict(type="CompileHook", compile_main=True),
 ]

--- a/configs/stable_diffusion_xl/stable_diffusion_xl_pokemon_blip_xformers.py
+++ b/configs/stable_diffusion_xl/stable_diffusion_xl_pokemon_blip_xformers.py
@@ -26,6 +26,6 @@ custom_hooks = [
         height=1024,
         width=1024),
     dict(type="SDCheckpointHook"),
-    dict(type="FastNormHook", fuse_unet_ln=True, fuse_gn=True),
-    dict(type="CompileHook", compile_unet=False),
+    dict(type="FastNormHook", fuse_main_ln=True, fuse_gn=True),
+    dict(type="CompileHook", compile_main=False),
 ]

--- a/diffengine/datasets/transforms/__init__.py
+++ b/diffengine/datasets/transforms/__init__.py
@@ -5,12 +5,14 @@ from .processing import (
     TRANSFORMS,
     CenterCrop,
     CLIPImageProcessor,
+    ComputePixArtImgInfo,
     ComputeTimeIds,
     MultiAspectRatioResizeCenterCrop,
     RandomCrop,
     RandomHorizontalFlip,
     RandomTextDrop,
     SaveImageShape,
+    T5TextPreprocess,
 )
 
 __all__ = [
@@ -26,4 +28,6 @@ __all__ = [
     "MultiAspectRatioResizeCenterCrop",
     "CLIPImageProcessor",
     "RandomTextDrop",
+    "ComputePixArtImgInfo",
+    "T5TextPreprocess",
 ]

--- a/diffengine/datasets/transforms/processing.py
+++ b/diffengine/datasets/transforms/processing.py
@@ -1,12 +1,15 @@
 # flake8: noqa: S311
+import html
 import inspect
 import random
 import re
+import urllib.parse as ul
 from collections.abc import Sequence
 from enum import EnumMeta
 
 import numpy as np
 import torchvision
+from diffusers.utils import is_bs4_available, is_ftfy_available
 from mmengine.dataset.base_dataset import Compose
 from torchvision.transforms.functional import crop
 from torchvision.transforms.transforms import InterpolationMode
@@ -14,6 +17,12 @@ from transformers import CLIPImageProcessor as HFCLIPImageProcessor
 
 from diffengine.datasets.transforms.base import BaseTransform
 from diffengine.registry import TRANSFORMS
+
+if is_bs4_available():
+    from bs4 import BeautifulSoup
+
+if is_ftfy_available():
+    import ftfy
 
 
 def _str_to_torch_dtype(t: str):
@@ -365,6 +374,30 @@ class ComputeTimeIds(BaseTransform):
 
 
 @TRANSFORMS.register_module()
+class ComputePixArtImgInfo(BaseTransform):
+    """Compute Orig Height and Widh + Aspect Ratio.
+
+    Return 'resolution', 'aspect_ratio' in results
+    """
+
+    def transform(self, results: dict) -> dict | tuple[list, list] | None:
+        """Transform.
+
+        Args:
+        ----
+            results (dict): The result dict.
+
+        Returns:
+        -------
+            dict: 'time_ids' key is added as original image shape.
+        """
+        assert "ori_img_shape" in results
+        results["resolution"] = results["ori_img_shape"]
+        results["aspect_ratio"] = results["img"].height / results["img"].width
+        return results
+
+
+@TRANSFORMS.register_module()
 class CLIPImageProcessor(BaseTransform):
     """CLIPImageProcessor.
 
@@ -420,4 +453,184 @@ class RandomTextDrop(BaseTransform):
         if random.random() < self.p:
             for k in self.keys:
                 results[k] = ""
+        return results
+
+
+
+@TRANSFORMS.register_module()
+class T5TextPreprocess(BaseTransform):
+    """T5 Text Preprocess.
+
+    Args:
+    ----
+        keys (List[str]): `keys` to apply augmentation from results.
+        clean_caption (bool): clean caption. Defaults to False.
+    """
+
+    def __init__(self, keys=None,
+                 *,
+                 clean_caption: bool = True) -> None:
+        if clean_caption:
+            assert is_ftfy_available(), "Please install ftfy."
+            assert is_bs4_available(), "Please install bs4."
+
+        if keys is None:
+            keys = ["text"]
+        self.keys = keys
+        self.clean_caption = clean_caption
+        self.bad_punct_regex = re.compile(
+            r"["  # noqa
+            + "#®•©™&@·º½¾¿¡§~"
+            + r"\)"
+            + r"\("
+            + r"\]"
+            + r"\["
+            + r"\}"
+            + r"\{"
+            + r"\|"
+            + "\\"
+            + r"\/"
+            + r"\*"
+            + r"]{1,}",
+        )
+
+    def _clean_caption(self, caption: str) -> str:  # noqa
+        """Clean caption.
+
+        Copied from
+        diffusers.pipelines.deepfloyd_if.pipeline_if.IFPipeline._clean_caption
+        """
+        caption = str(caption)
+        caption = ul.unquote_plus(caption)
+        caption = caption.strip().lower()
+        caption = re.sub("<person>", "person", caption)
+        # urls:
+        caption = re.sub(
+            r"\b((?:https?:(?:\/{1,3}|[a-zA-Z0-9%])|[a-zA-Z0-9.\-]+[.](?:com|co|ru|net|org|edu|gov|it)[\w/-]*\b\/?(?!@)))",
+            "",
+            caption,
+        )  # regex for urls
+        caption = re.sub(
+            r"\b((?:www:(?:\/{1,3}|[a-zA-Z0-9%])|[a-zA-Z0-9.\-]+[.](?:com|co|ru|net|org|edu|gov|it)[\w/-]*\b\/?(?!@)))",
+            "",
+            caption,
+        )  # regex for urls
+        # html:
+        caption = BeautifulSoup(caption, features="html.parser").text
+
+        # @<nickname>
+        caption = re.sub(r"@[\w\d]+\b", "", caption)
+
+        # 31C0—31EF CJK Strokes
+        # 31F0—31FF Katakana Phonetic Extensions
+        # 3200—32FF Enclosed CJK Letters and Months
+        # 3300—33FF CJK Compatibility
+        # 3400—4DBF CJK Unified Ideographs Extension A
+        # 4DC0—4DFF Yijing Hexagram Symbols
+        # 4E00—9FFF CJK Unified Ideographs
+        caption = re.sub(r"[\u31c0-\u31ef]+", "", caption)
+        caption = re.sub(r"[\u31f0-\u31ff]+", "", caption)
+        caption = re.sub(r"[\u3200-\u32ff]+", "", caption)
+        caption = re.sub(r"[\u3300-\u33ff]+", "", caption)
+        caption = re.sub(r"[\u3400-\u4dbf]+", "", caption)
+        caption = re.sub(r"[\u4dc0-\u4dff]+", "", caption)
+        caption = re.sub(r"[\u4e00-\u9fff]+", "", caption)
+        #######################################################
+
+        # все виды тире / all types of dash --> "-"
+        caption = re.sub(
+            r"[\u002D\u058A\u05BE\u1400\u1806\u2010-\u2015\u2E17\u2E1A\u2E3A\u2E3B\u2E40\u301C\u3030\u30A0\uFE31\uFE32\uFE58\uFE63\uFF0D]+",
+            "-",
+            caption,
+        )
+
+        # кавычки к одному стандарту
+        caption = re.sub(r"[`´«»“”¨]", '"', caption)  # noqa
+        caption = re.sub(r"[‘’]", "'", caption)  # noqa
+
+        # &quot;
+        caption = re.sub(r"&quot;?", "", caption)
+        # &amp
+        caption = re.sub(r"&amp", "", caption)
+
+        # ip addresses:
+        caption = re.sub(r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", " ", caption)
+
+        # article ids:
+        caption = re.sub(r"\d:\d\d\s+$", "", caption)
+
+        # \n
+        caption = re.sub(r"\\n", " ", caption)
+
+        # "#123"
+        caption = re.sub(r"#\d{1,3}\b", "", caption)
+        # "#12345.."
+        caption = re.sub(r"#\d{5,}\b", "", caption)
+        # "123456.."
+        caption = re.sub(r"\b\d{6,}\b", "", caption)
+        # filenames:
+        caption = re.sub(
+            r"[\S]+\.(?:png|jpg|jpeg|bmp|webp|eps|pdf|apk|mp4)", "", caption)
+
+        #
+        caption = re.sub(r"[\"\']{2,}", r'"', caption)  # """AUSVERKAUFT"""
+        caption = re.sub(r"[\.]{2,}", r" ", caption)  # """AUSVERKAUFT"""
+
+        # ***AUSVERKAUFT***, #AUSVERKAUFT
+        caption = re.sub(self.bad_punct_regex, r" ", caption)
+        caption = re.sub(r"\s+\.\s+", r" ", caption)  # " . "
+
+        # this-is-my-cute-cat / this_is_my_cute_cat
+        regex2 = re.compile(r"(?:\-|\_)")
+        if len(re.findall(regex2, caption)) > 3:  # noqa
+            caption = re.sub(regex2, " ", caption)
+
+        caption = ftfy.fix_text(caption)
+        caption = html.unescape(html.unescape(caption))
+
+        caption = re.sub(r"\b[a-zA-Z]{1,3}\d{3,15}\b", "", caption)  # jc6640
+        caption = re.sub(r"\b[a-zA-Z]+\d+[a-zA-Z]+\b", "", caption)  # jc6640vc
+        caption = re.sub(r"\b\d+[a-zA-Z]+\d+\b", "", caption)  # 6640vc231
+
+        caption = re.sub(r"(worldwide\s+)?(free\s+)?shipping", "", caption)
+        caption = re.sub(r"(free\s)?download(\sfree)?", "", caption)
+        caption = re.sub(r"\bclick\b\s(?:for|on)\s\w+", "", caption)
+        caption = re.sub(
+            r"\b(?:png|jpg|jpeg|bmp|webp|eps|pdf|apk|mp4)(\simage[s]?)?", "",
+            caption)
+        caption = re.sub(r"\bpage\s+\d+\b", "", caption)
+
+        # j2d1a2a...
+        caption = re.sub(
+            r"\b\d*[a-zA-Z]+\d+[a-zA-Z]+\d+[a-zA-Z\d]*\b", r" ", caption)
+
+        caption = re.sub(r"\b\d+\.?\d*[xх×]\d+\.?\d*\b", "", caption)  # noqa
+
+        caption = re.sub(r"\b\s+\:\s+", r": ", caption)
+        caption = re.sub(r"(\D[,\./])\b", r"\1 ", caption)
+        caption = re.sub(r"\s+", " ", caption)
+
+        caption.strip()
+
+        caption = re.sub(r"^[\"\']([\w\W]+)[\"\']$", r"\1", caption)
+        caption = re.sub(r"^[\'\_,\-\:;]", r"", caption)
+        caption = re.sub(r"[\'\_,\-\:\-\+]$", r"", caption)
+        caption = re.sub(r"^\.\S+$", "", caption)
+
+        return caption.strip()
+
+    def transform(self, results: dict) -> dict | tuple[list, list] | None:
+        """Transform.
+
+        Args:
+        ----
+            results (dict): The result dict.
+        """
+        for k in self.keys:
+            text = results[k]
+            if self.clean_caption:
+                text = self._clean_caption(text)
+            else:
+                text = text.lower().strip()
+            results[k] = text
         return results

--- a/diffengine/datasets/transforms/processing.py
+++ b/diffengine/datasets/transforms/processing.py
@@ -392,7 +392,7 @@ class ComputePixArtImgInfo(BaseTransform):
             dict: 'time_ids' key is added as original image shape.
         """
         assert "ori_img_shape" in results
-        results["resolution"] = results["ori_img_shape"]
+        results["resolution"] = [float(s) for s in results["ori_img_shape"]]
         results["aspect_ratio"] = results["img"].height / results["img"].width
         return results
 

--- a/diffengine/engine/hooks/__init__.py
+++ b/diffengine/engine/hooks/__init__.py
@@ -4,6 +4,7 @@ from .fast_norm_hook import FastNormHook
 from .ip_adapter_save_hook import IPAdapterSaveHook
 from .lcm_ema_update_hook import LCMEMAUpdateHook
 from .peft_save_hook import PeftSaveHook
+from .pixart_checkpoint_hook import PixArtCheckpointHook
 from .sd_checkpoint_hook import SDCheckpointHook
 from .t2i_adapter_save_hook import T2IAdapterSaveHook
 from .unet_ema_hook import UnetEMAHook
@@ -22,4 +23,5 @@ __all__ = [
     "FastNormHook",
     "WuerstchenSaveHook",
     "LCMEMAUpdateHook",
+    "PixArtCheckpointHook",
 ]

--- a/diffengine/engine/hooks/peft_save_hook.py
+++ b/diffengine/engine/hooks/peft_save_hook.py
@@ -62,5 +62,8 @@ class PeftSaveHook(Hook):
         for model_key in model_keys:
             state_dict = get_peft_model_state_dict(getattr(model, model_key))
             for k in state_dict:
-                new_ckpt[f"{model_key}.{k}"] = state_dict[k]
+                # add adapter name
+                new_k = ".".join(
+                    k.split(".")[:-1] + ["default", k.split(".")[-1]])
+                new_ckpt[f"{model_key}.{new_k}"] = state_dict[k]
         checkpoint["state_dict"] = new_ckpt

--- a/diffengine/engine/hooks/peft_save_hook.py
+++ b/diffengine/engine/hooks/peft_save_hook.py
@@ -39,6 +39,10 @@ class PeftSaveHook(Hook):
         elif hasattr(model, "prior"):
             model.prior.save_pretrained(osp.join(ckpt_path, "prior"))
             model_keys = ["prior"]
+        elif hasattr(model, "transformer"):
+            model.transformer.save_pretrained(
+                osp.join(ckpt_path, "transformer"))
+            model_keys = ["transformer"]
 
         if hasattr(model,
                    "finetune_text_encoder") and model.finetune_text_encoder:

--- a/diffengine/engine/hooks/pixart_checkpoint_hook.py
+++ b/diffengine/engine/hooks/pixart_checkpoint_hook.py
@@ -1,0 +1,38 @@
+from collections import OrderedDict
+
+from mmengine.hooks import Hook
+from mmengine.model import is_model_wrapper
+from mmengine.registry import HOOKS
+
+
+@HOOKS.register_module()
+class PixArtCheckpointHook(Hook):
+    """Delete 'vae' from checkpoint for efficient save."""
+
+    priority = "VERY_LOW"
+
+    def before_save_checkpoint(self, runner, checkpoint: dict) -> None:
+        """Before save checkpoint hook.
+
+        Args:
+        ----
+            runner (Runner): The runner of the training, validation or testing
+                process.
+            checkpoint (dict): Model's checkpoint.
+        """
+        model = runner.model
+        if is_model_wrapper(model):
+            model = model.module
+
+        new_ckpt = OrderedDict()
+        sd_keys = checkpoint["state_dict"].keys()
+        for k in sd_keys:
+            if k.startswith("transformer"):
+                new_ckpt[k] = checkpoint["state_dict"][k]
+            elif k.startswith("text_encoder") and hasattr(
+                    model,
+                    "finetune_text_encoder",
+            ) and model.finetune_text_encoder:
+                # if not finetune text_encoder, then not save
+                new_ckpt[k] = checkpoint["state_dict"][k]
+        checkpoint["state_dict"] = new_ckpt

--- a/diffengine/models/editors/__init__.py
+++ b/diffengine/models/editors/__init__.py
@@ -4,6 +4,7 @@ from .esd import *  # noqa: F403
 from .instruct_pix2pix import *  # noqa: F403
 from .ip_adapter import *  # noqa: F403
 from .lcm import *  # noqa: F403
+from .pixart_alpha import *  # noqa: F403
 from .ssd_1b import *  # noqa: F403
 from .stable_diffusion import *  # noqa: F403
 from .stable_diffusion_controlnet import *  # noqa: F403

--- a/diffengine/models/editors/pixart_alpha/__init__.py
+++ b/diffengine/models/editors/pixart_alpha/__init__.py
@@ -1,0 +1,4 @@
+from .pixart_alpha import PixArtAlpha
+from .pixart_alpha_data_preprocessor import PixArtAlphaDataPreprocessor
+
+__all__ = ["PixArtAlpha", "PixArtAlphaDataPreprocessor"]

--- a/diffengine/models/editors/pixart_alpha/pixart_alpha.py
+++ b/diffengine/models/editors/pixart_alpha/pixart_alpha.py
@@ -233,11 +233,16 @@ class PixArtAlpha(BaseModel):
         pipeline = PixArtAlphaPipeline.from_pretrained(
             self.model,
             vae=self.vae,
-            text_encoder=self.text_encoder,
+            # text_encoder=self.text_encoder,
             tokenizer=self.tokenizer,
             transformer=self.transformer,
             torch_dtype=torch.float32,
         )
+        if self.finetune_text_encoder:
+            # todo[takuoko]: When parsing text_encoder directly, the  # noqa
+            # results are different. So we need to parse here.
+            pipeline.text_encoder = self.text_encoder
+        pipeline.to(self.device)
         if self.prediction_type is not None:
             # set prediction_type of scheduler if defined
             scheduler_args = {"prediction_type": self.prediction_type}
@@ -394,6 +399,5 @@ class PixArtAlpha(BaseModel):
         latent_channels = self.transformer.config.in_channels
         if self.transformer.config.out_channels // 2 == latent_channels:
             model_pred = model_pred.chunk(2, dim=1)[0]
-
 
         return self.loss(model_pred, noise, latents, timesteps, weight)

--- a/diffengine/models/editors/pixart_alpha/pixart_alpha.py
+++ b/diffengine/models/editors/pixart_alpha/pixart_alpha.py
@@ -236,8 +236,7 @@ class PixArtAlpha(BaseModel):
             text_encoder=self.text_encoder,
             tokenizer=self.tokenizer,
             transformer=self.transformer,
-            torch_dtype=(torch.float16 if self.device != torch.device("cpu")
-                         else torch.float32),
+            torch_dtype=torch.float32,
         )
         if self.prediction_type is not None:
             # set prediction_type of scheduler if defined

--- a/diffengine/models/editors/pixart_alpha/pixart_alpha.py
+++ b/diffengine/models/editors/pixart_alpha/pixart_alpha.py
@@ -1,0 +1,388 @@
+from copy import deepcopy
+from typing import Optional, Union
+
+import numpy as np
+import torch
+from diffusers import (
+    AutoencoderKL,
+    DDPMScheduler,
+    PixArtAlphaPipeline,
+    Transformer2DModel,
+)
+from mmengine import print_log
+from mmengine.model import BaseModel
+from peft import get_peft_model
+from torch import nn
+from transformers import T5EncoderModel, T5Tokenizer
+
+from diffengine.models.archs import create_peft_config
+from diffengine.registry import MODELS
+
+
+@MODELS.register_module()
+class PixArtAlpha(BaseModel):
+    """PixArt Alpha.
+
+    Args:
+    ----
+        model (str): pretrained model name of stable diffusion.
+            Defaults to 'runwayml/stable-diffusion-v1-5'.
+        loss (dict): Config of loss. Defaults to
+            ``dict(type='L2Loss', loss_weight=1.0)``.
+        transformer_lora_config (dict, optional): The LoRA config dict for
+            Transformer. example. dict(type="LoRA", r=4). `type` is chosen from
+            `LoRA`, `LoHa`, `LoKr`. Other config are same as the config of
+            PEFT. https://github.com/huggingface/peft
+            Defaults to None.
+        text_encoder_lora_config (dict, optional): The LoRA config dict for
+            Text Encoder. example. dict(type="LoRA", r=4). `type` is chosen
+            from `LoRA`, `LoHa`, `LoKr`. Other config are same as the config of
+            PEFT. https://github.com/huggingface/peft
+            Defaults to None.
+        prior_loss_weight (float): The weight of prior preservation loss.
+            It works when training dreambooth with class images.
+        tokenizer_max_length (int): The max length of tokenizer.
+            Defaults to 120.
+        prediction_type (str): The prediction_type that shall be used for
+            training. Choose between 'epsilon' or 'v_prediction' or leave
+            `None`. If left to `None` the default prediction type of the
+        data_preprocessor (dict, optional): The pre-process config of
+            :class:`PixArtAlphaDataPreprocessor`.
+        noise_generator (dict, optional): The noise generator config.
+            Defaults to ``dict(type='WhiteNoise')``.
+        timesteps_generator (dict, optional): The timesteps generator config.
+            Defaults to ``dict(type='TimeSteps')``.
+        input_perturbation_gamma (float): The gamma of input perturbation.
+            The recommended value is 0.1 for Input Perturbation.
+            Defaults to 0.0.
+        finetune_text_encoder (bool, optional): Whether to fine-tune text
+            encoder. Defaults to False.
+        gradient_checkpointing (bool): Whether or not to use gradient
+            checkpointing to save memory at the expense of slower backward
+            pass. Defaults to False.
+        enable_xformers (bool): Whether or not to enable memory efficient
+            attention. Defaults to False.
+    """
+
+    def __init__(
+        self,
+        model: str = "runwayml/stable-diffusion-v1-5",
+        loss: dict | None = None,
+        transformer_lora_config: dict | None = None,
+        text_encoder_lora_config: dict | None = None,
+        prior_loss_weight: float = 1.,
+        tokenizer_max_length: int = 120,
+        prediction_type: str | None = None,
+        data_preprocessor: dict | nn.Module | None = None,
+        noise_generator: dict | None = None,
+        timesteps_generator: dict | None = None,
+        input_perturbation_gamma: float = 0.0,
+        *,
+        finetune_text_encoder: bool = False,
+        gradient_checkpointing: bool = False,
+        enable_xformers: bool = False,
+    ) -> None:
+        if data_preprocessor is None:
+            data_preprocessor = {"type": "PixArtAlphaDataPreprocessor"}
+        if noise_generator is None:
+            noise_generator = {"type": "WhiteNoise"}
+        if timesteps_generator is None:
+            timesteps_generator = {"type": "TimeSteps"}
+        if loss is None:
+            loss = {"type": "L2Loss", "loss_weight": 1.0}
+        super().__init__(data_preprocessor=data_preprocessor)
+        if (
+            transformer_lora_config is not None) and (
+                text_encoder_lora_config is not None) and (
+                    not finetune_text_encoder):
+                print_log(
+                    "You are using LoRA for Transformer and text encoder. "
+                    "But you are not set `finetune_text_encoder=True`. "
+                    "We will set `finetune_text_encoder=True` for you.")
+                finetune_text_encoder = True
+        if text_encoder_lora_config is not None:
+            assert finetune_text_encoder, (
+                "If you want to use LoRA for text encoder, "
+                "you should set finetune_text_encoder=True."
+            )
+        if finetune_text_encoder and transformer_lora_config is not None:
+            assert text_encoder_lora_config is not None, (
+                "If you want to finetune text encoder with LoRA Transformer, "
+                "you should set text_encoder_lora_config."
+            )
+
+        self.model = model
+        self.transformer_lora_config = deepcopy(transformer_lora_config)
+        self.text_encoder_lora_config = deepcopy(text_encoder_lora_config)
+        self.finetune_text_encoder = finetune_text_encoder
+        self.prior_loss_weight = prior_loss_weight
+        self.tokenizer_max_length = tokenizer_max_length
+        self.gradient_checkpointing = gradient_checkpointing
+        self.input_perturbation_gamma = input_perturbation_gamma
+        self.enable_xformers = enable_xformers
+
+        if not isinstance(loss, nn.Module):
+            loss = MODELS.build(loss)
+        self.loss_module: nn.Module = loss
+
+        assert prediction_type in [None, "epsilon", "v_prediction"]
+        self.prediction_type = prediction_type
+
+        self.tokenizer = T5Tokenizer.from_pretrained(
+            model, subfolder="tokenizer")
+        self.scheduler = DDPMScheduler.from_pretrained(
+            model, subfolder="scheduler")
+
+        self.text_encoder = T5EncoderModel.from_pretrained(
+            model, subfolder="text_encoder")
+        self.vae = AutoencoderKL.from_pretrained(model, subfolder="vae")
+        self.transformer = Transformer2DModel.from_pretrained(
+            model, subfolder="transformer")
+        self.noise_generator = MODELS.build(noise_generator)
+        self.timesteps_generator = MODELS.build(timesteps_generator)
+        self.prepare_model()
+        self.set_lora()
+        self.set_xformers()
+
+    def set_lora(self) -> None:
+        """Set LORA for model."""
+        if self.text_encoder_lora_config is not None:
+            text_encoder_lora_config = create_peft_config(
+                self.text_encoder_lora_config)
+            self.text_encoder = get_peft_model(
+                self.text_encoder, text_encoder_lora_config)
+            self.text_encoder.print_trainable_parameters()
+        if self.transformer_lora_config is not None:
+            transformer_lora_config = create_peft_config(self.transformer_lora_config)
+            self.transformer = get_peft_model(self.transformer, transformer_lora_config)
+            self.transformer.print_trainable_parameters()
+
+    def prepare_model(self) -> None:
+        """Prepare model for training.
+
+        Disable gradient for some models.
+        """
+        if self.gradient_checkpointing:
+            self.transformer.enable_gradient_checkpointing()
+            if self.finetune_text_encoder:
+                self.text_encoder.gradient_checkpointing_enable()
+
+        self.vae.requires_grad_(requires_grad=False)
+        print_log("Set VAE untrainable.", "current")
+        if not self.finetune_text_encoder:
+            self.text_encoder.requires_grad_(requires_grad=False)
+            print_log("Set Text Encoder untrainable.", "current")
+
+    def set_xformers(self) -> None:
+        """Set xformers for model."""
+        if self.enable_xformers:
+            from diffusers.utils.import_utils import is_xformers_available
+            if is_xformers_available():
+                self.transformer.enable_xformers_memory_efficient_attention()
+            else:
+                msg = "Please install xformers to enable memory efficient attention."
+                raise ImportError(
+                    msg,
+                )
+
+    @property
+    def device(self) -> torch.device:
+        """Get device information.
+
+        Returns
+        -------
+            torch.device: device.
+        """
+        return next(self.parameters()).device
+
+    @torch.no_grad()
+    def infer(self,
+              prompt: list[str],
+              negative_prompt: str | None = None,
+              height: int | None = None,
+              width: int | None = None,
+              num_inference_steps: int = 50,
+              output_type: str = "pil",
+              **kwargs) -> list[np.ndarray]:
+        """Inference function.
+
+        Args:
+        ----
+            prompt (`List[str]`):
+                The prompt or prompts to guide the image generation.
+            negative_prompt (`Optional[str]`):
+                The prompt or prompts to guide the image generation.
+                Defaults to None.
+            height (int, optional):
+                The height in pixels of the generated image. Defaults to None.
+            width (int, optional):
+                The width in pixels of the generated image. Defaults to None.
+            num_inference_steps (int): Number of inference steps.
+                Defaults to 50.
+            output_type (str): The output format of the generate image.
+                Choose between 'pil' and 'latent'. Defaults to 'pil'.
+            **kwargs: Other arguments.
+        """
+        pipeline = PixArtAlphaPipeline.from_pretrained(
+            self.model,
+            vae=self.vae,
+            text_encoder=self.text_encoder,
+            tokenizer=self.tokenizer,
+            transformer=self.transformer,
+            torch_dtype=(torch.float16 if self.device != torch.device("cpu")
+                         else torch.float32),
+        )
+        if self.prediction_type is not None:
+            # set prediction_type of scheduler if defined
+            scheduler_args = {"prediction_type": self.prediction_type}
+            pipeline.scheduler = pipeline.scheduler.from_config(
+                pipeline.scheduler.config, **scheduler_args)
+        pipeline.set_progress_bar_config(disable=True)
+        images = []
+        for p in prompt:
+            image = pipeline(
+                p,
+                negative_prompt=negative_prompt,
+                num_inference_steps=num_inference_steps,
+                height=height,
+                width=width,
+                output_type=output_type,
+                **kwargs).images[0]
+            if output_type == "latent":
+                images.append(image)
+            else:
+                images.append(np.array(image))
+
+        del pipeline
+        torch.cuda.empty_cache()
+
+        return images
+
+    def val_step(
+            self,
+            data: Union[tuple, dict, list]  # noqa
+    ) -> list:
+        """Val step."""
+        msg = "val_step is not implemented now, please use infer."
+        raise NotImplementedError(msg)
+
+    def test_step(
+            self,
+            data: Union[tuple, dict, list]  # noqa
+    ) -> list:
+        """Test step."""
+        msg = "test_step is not implemented now, please use infer."
+        raise NotImplementedError(msg)
+
+    def loss(self,
+             model_pred: torch.Tensor,
+             noise: torch.Tensor,
+             latents: torch.Tensor,
+             timesteps: torch.Tensor,
+             weight: torch.Tensor | None = None) -> dict[str, torch.Tensor]:
+        """Calculate loss."""
+        if self.prediction_type is not None:
+            # set prediction_type of scheduler if defined
+            self.scheduler.register_to_config(
+                prediction_type=self.prediction_type)
+
+        if self.scheduler.config.prediction_type == "epsilon":
+            gt = noise
+        elif self.scheduler.config.prediction_type == "v_prediction":
+            gt = self.scheduler.get_velocity(latents, noise, timesteps)
+        else:
+            msg = f"Unknown prediction type {self.scheduler.config.prediction_type}"
+            raise ValueError(msg)
+
+        loss_dict = {}
+        # calculate loss in FP32
+        if self.loss_module.use_snr:
+            loss = self.loss_module(
+                model_pred.float(),
+                gt.float(),
+                timesteps,
+                self.scheduler.alphas_cumprod,
+                self.scheduler.config.prediction_type,
+                weight=weight)
+        else:
+            loss = self.loss_module(
+                model_pred.float(), gt.float(), weight=weight)
+        loss_dict["loss"] = loss
+        return loss_dict
+
+    def _preprocess_model_input(self,
+                                latents: torch.Tensor,
+                                noise: torch.Tensor,
+                                timesteps: torch.Tensor) -> torch.Tensor:
+        """Preprocess model input."""
+        if self.input_perturbation_gamma > 0:
+            input_noise = noise + self.input_perturbation_gamma * torch.randn_like(
+                noise)
+        else:
+            input_noise = noise
+        return self.scheduler.add_noise(latents, input_noise, timesteps)
+
+    def forward(
+            self,
+            inputs: dict,
+            data_samples: Optional[list] = None,  # noqa
+            mode: str = "loss") -> dict:
+        """Forward function.
+
+        Args:
+        ----
+            inputs (dict): The input dict.
+            data_samples (Optional[list], optional): The data samples.
+                Defaults to None.
+            mode (str, optional): The mode. Defaults to "loss".
+
+        Returns:
+        -------
+            dict: The loss dict.
+        """
+        assert mode == "loss"
+        text_inputs = self.tokenizer(
+            inputs["text"],
+            max_length=self.tokenizer_max_length,
+            padding="max_length",
+            truncation=True,
+            return_tensors="pt")
+        inputs["text"] = text_inputs.input_ids.to(self.device)
+        inputs["attention_mask"] = text_inputs.attention_mask.to(self.device)
+        num_batches = len(inputs["img"])
+        if "result_class_image" in inputs:
+            # use prior_loss_weight
+            weight = torch.cat([
+                torch.ones((num_batches // 2, )),
+                torch.ones((num_batches // 2, )) * self.prior_loss_weight,
+            ]).to(self.device).float().reshape(-1, 1, 1, 1)
+        else:
+            weight = None
+
+        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
+        latents = latents * self.vae.config.scaling_factor
+
+        noise = self.noise_generator(latents)
+
+        timesteps = self.timesteps_generator(self.scheduler, num_batches,
+                                            self.device)
+
+        noisy_latents = self._preprocess_model_input(latents, noise, timesteps)
+
+        encoder_hidden_states = self.text_encoder(
+            inputs["text"], attention_mask=inputs["attention_mask"])[0]
+
+        if self.transformer.config.sample_size == 128:  # noqa
+            added_cond_kwargs = {"resolution": inputs["resolution"],
+                                 "aspect_ratio": inputs["aspect_ratio"]}
+        else:
+            added_cond_kwargs = {"resolution": None, "aspect_ratio": None}
+
+        model_pred = self.transformer(
+            noisy_latents,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=inputs["attention_mask"],
+            timestep=timesteps,
+            added_cond_kwargs=added_cond_kwargs).sample
+
+        return self.loss(model_pred, noise, latents, timesteps, weight)

--- a/diffengine/models/editors/pixart_alpha/pixart_alpha_data_preprocessor.py
+++ b/diffengine/models/editors/pixart_alpha/pixart_alpha_data_preprocessor.py
@@ -1,0 +1,54 @@
+import torch
+from mmengine.model.base_model.data_preprocessor import BaseDataPreprocessor
+
+from diffengine.registry import MODELS
+
+
+@MODELS.register_module()
+class PixArtAlphaDataPreprocessor(BaseDataPreprocessor):
+    """PixArtAlphaDataPreprocessor."""
+
+    def forward(
+            self,
+            data: dict,
+            training: bool = False  # noqa
+    ) -> dict | list:
+        """Preprocesses the data into the model input format.
+
+        After the data pre-processing of :meth:`cast_data`, ``forward``
+        will stack the input tensor list to a batch tensor at the first
+        dimension.
+
+        Args:
+        ----
+            data (dict): Data returned by dataloader
+            training (bool): Whether to enable training time augmentation.
+
+        Returns:
+        -------
+            dict or list: Data in the same format as the model input.
+        """
+        if "result_class_image" in data["inputs"]:
+            # dreambooth with class image
+            data["inputs"]["text"] = data["inputs"]["text"] + data["inputs"][
+                "result_class_image"].pop("text")
+            data["inputs"]["img"] = data["inputs"]["img"] + data["inputs"][
+                "result_class_image"].pop("img")
+            if "resolution" in data["inputs"]:
+                data["inputs"]["resolution"] = data["inputs"][
+                    "resolution"] + data[
+                        "inputs"]["result_class_image"].pop("resolution")
+            if "aspect_ratio" in data["inputs"]:
+                data["inputs"]["aspect_ratio"] = data["inputs"][
+                    "aspect_ratio"] + data[
+                        "inputs"]["result_class_image"].pop("aspect_ratio")
+
+        data["inputs"]["img"] = torch.stack(data["inputs"]["img"])
+        # pre-compute text embeddings
+        if "resolution" in data["inputs"]:
+            data["inputs"]["resolution"] = torch.stack(
+                data["inputs"]["resolution"])
+        if "aspect_ratio" in data["inputs"]:
+            data["inputs"]["aspect_ratio"] = torch.stack(
+                data["inputs"]["aspect_ratio"])
+        return super().forward(data)

--- a/docs/source/run_guides/run_dreambooth_xl.md
+++ b/docs/source/run_guides/run_dreambooth_xl.md
@@ -8,6 +8,18 @@ All configuration files are placed under the [`configs/stable_diffusion_xl_dream
 
 Following is the example config fixed from the stable_diffusion_xl_dreambooth_lora_dog config file in [`configs/stable_diffusion_xl_dreambooth/stable_diffusion_xl_dreambooth_lora_dog.py`](../../../configs/stable_diffusion_xl_dreambooth/stable_diffusion_xl_dreambooth_lora_dog.py):
 
+```
+_base_ = [
+    "../_base_/models/stable_diffusion_xl_lora.py",
+    "../_base_/datasets/dog_dreambooth_xl.py",
+    "../_base_/schedules/stable_diffusion_500.py",
+    "../_base_/default_runtime.py",
+]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}})))
+```
+
 #### Finetuning the text encoder and UNet
 
 The script also allows you to finetune the text_encoder along with the unet.

--- a/docs/source/run_guides/run_pixart_alpha.md
+++ b/docs/source/run_guides/run_pixart_alpha.md
@@ -1,0 +1,89 @@
+# PixArt-α Training
+
+You can also check [`configs/pixart_alpha/README.md`](../../../configs/pixart_alpha/README.md) file.
+
+## Configs
+
+All configuration files are placed under the [`configs/pixart_alpha`](../../../configs/pixart_alpha/) folder.
+
+Following is the example config fixed from the stable_diffusion_xl_pokemon_blip config file in [`configs/pixart_alpha/pixart_alpha_1024_pokemon_blip.py`](../../../configs/pixart_alpha/pixart_alpha_1024_pokemon_blip.py):
+
+```
+_base_ = [
+    "../_base_/models/pixart_alpha_1024.py",
+    "../_base_/datasets/pokemon_blip_pixart.py",
+    "../_base_/schedules/stable_diffusion_50e.py",
+    "../_base_/default_runtime.py",
+]
+
+optim_wrapper = dict(
+    dtype="bfloat16",
+    optimizer=dict(lr=2e-6, weight_decay=3e-2),
+    clip_grad=dict(max_norm=0.01))
+```
+
+## Run training
+
+Run train
+
+```
+# single gpu
+$ mim train diffengine ${CONFIG_FILE}
+# multi gpus
+$ mim train diffengine ${CONFIG_FILE} --gpus 2 --launcher pytorch
+
+# Example.
+$ mim train diffengine configs/pixart_alpha/pixart_alpha_1024_pokemon_blip.py
+```
+
+## Inference with diffusers
+
+Once you have trained a model, specify the path to the saved model and utilize it for inference using the `diffusers.pipeline` module.
+
+Before inferencing, we should convert weights for diffusers format,
+
+```bash
+$ mim run diffengine publish_model2diffusers ${CONFIG_FILE} ${INPUT_FILENAME} ${OUTPUT_DIR} --save-keys ${SAVE_KEYS}
+# Example
+$ mim run diffengine publish_model2diffusers configs/pixart_alpha/pixart_alpha_1024_pokemon_blip.py work_dirs/pixart_alpha_1024_pokemon_blip/epoch_50.pth work_dirs/pixart_alpha_1024_pokemon_blip --save-keys transformer
+```
+
+Then we can run inference.
+
+```py
+from pathlib import Path
+
+import torch
+from diffusers import PixArtAlphaPipeline, AutoencoderKL, Transformer2DModel
+from peft import PeftModel
+
+checkpoint = Path('work_dirs/pixart_alpha_1024_pokemon_blip')
+prompt = 'yoda pokemon'
+
+vae = AutoencoderKL.from_pretrained(
+    'stabilityai/sd-vae-ft-ema',
+)
+transformer = Transformer2DModel.from_pretrained(checkpoint, subfolder='transformer')
+pipe = PixArtAlphaPipeline.from_pretrained(
+    "PixArt-alpha/PixArt-XL-2-1024-MS",
+    vae=vae,
+    transformer=transformer,
+    torch_dtype=torch.float32,
+).to("cuda")
+
+img = pipe(
+    prompt,
+    width=1024,
+    height=1024,
+    num_inference_steps=50,
+).images[0]
+img.save("demo.png")
+```
+
+## Results Example
+
+#### pixart_alpha_1024_pokemon_blip
+
+![example1](https://github.com/okotaku/diffengine/assets/24734142/5029f450-d248-4f22-8f90-6588f1d5f91e)
+
+You can check [`configs/pixart_alpha/README.md`](../../../configs/pixart_alpha/README.md#results-example) for more details.

--- a/docs/source/run_guides/run_pixart_alpha.md
+++ b/docs/source/run_guides/run_pixart_alpha.md
@@ -84,6 +84,6 @@ img.save("demo.png")
 
 #### pixart_alpha_1024_pokemon_blip
 
-![example1](https://github.com/okotaku/diffengine/assets/24734142/5029f450-d248-4f22-8f90-6588f1d5f91e)
+![example1](https://github.com/okotaku/diffengine/assets/24734142/6b87369a-4746-4067-9a8a-5d7453fc80ce)
 
 You can check [`configs/pixart_alpha/README.md`](../../../configs/pixart_alpha/README.md#results-example) for more details.

--- a/docs/source/run_guides/run_pixart_alpha_dreambooth.md
+++ b/docs/source/run_guides/run_pixart_alpha_dreambooth.md
@@ -1,0 +1,86 @@
+# PixArt-α DremBooth Training
+
+You can also check [`configs/pixart_alpha_dreambooth/README.md`](../../../configs/pixart_alpha_dreambooth/README.md) file.
+
+## Configs
+
+All configuration files are placed under the [`configs/pixart_alpha_dreambooth`](../../../configs/pixart_alpha_dreambooth/) folder.
+
+Following is the example config fixed from the pixart_alpha_1024_dreambooth_lora_dog config file in [`configs/pixart_alpha_dreambooth/pixart_alpha_1024_dreambooth_lora_dog.py`](../../../configs/pixart_alpha_dreambooth/pixart_alpha_1024_dreambooth_lora_dog.py):
+
+```
+_base_ = [
+    "../_base_/models/pixart_alpha_1024_lora.py",
+    "../_base_/datasets/dog_dreambooth_pixart_1024.py",
+    "../_base_/schedules/stable_diffusion_500.py",
+    "../_base_/default_runtime.py",
+]
+
+train_dataloader = dict(
+    dataset=dict(class_image_config=dict(model={{_base_.model.model}})))
+
+optim_wrapper = dict(
+    dtype="bfloat16",
+    optimizer=dict(lr=1e-4))
+```
+
+## Run DreamBooth training
+
+Run DreamBooth train
+
+```
+# single gpu
+$ mim train diffengine ${CONFIG_FILE}
+# multi gpus
+$ mim train diffengine ${CONFIG_FILE} --gpus 2 --launcher pytorch
+
+# Example.
+$ mim train diffengine configs/pixart_alpha_dreambooth/pixart_alpha_1024_dreambooth_lora_dog.py
+```
+
+## Inference with diffusers
+
+Once you have trained a model, specify the path to the saved model and utilize it for inference using the `diffusers.pipeline` module.
+
+```py
+from pathlib import Path
+
+import torch
+from diffusers import PixArtAlphaPipeline, AutoencoderKL
+from peft import PeftModel
+
+checkpoint = Path('work_dirs/pixart_alpha_1024_dreambooth_lora_dog/step499')
+prompt = 'A photo of sks dog in a bucket'
+
+vae = AutoencoderKL.from_pretrained(
+    'stabilityai/sd-vae-ft-ema',
+)
+pipe = PixArtAlphaPipeline.from_pretrained(
+    "PixArt-alpha/PixArt-XL-2-1024-MS",
+    vae=vae,
+    torch_dtype=torch.float32,
+).to("cuda")
+pipe.transformer = PeftModel.from_pretrained(pipe.transformer, checkpoint / "transformer", adapter_name="default")
+
+img = pipe(
+    prompt,
+    width=1024,
+    height=1024,
+    num_inference_steps=50,
+).images[0]
+img.save("demo.png")
+```
+
+You can check [inference docs](inference.md) for inferencing other settings like Full Parameter Training without LoRA.
+
+## Results Example
+
+#### pixart_alpha_512_dreambooth_lora_dog
+
+![exampledog](https://github.com/okotaku/diffengine/assets/24734142/2d3b59b1-2a9b-422d-adba-347504c66be2)
+
+#### pixart_alpha_1024_dreambooth_lora_dog
+
+![exampledog2](https://github.com/okotaku/diffengine/assets/24734142/a3fc9fcd-7cd0-4dc2-997d-3a9b303c228a)
+
+You can check [`configs/pixart_alpha_dreambooth/README.md`](../../../configs/pixart_alpha_dreambooth/README.md#results-example) for more details.

--- a/docs/source/run_guides/run_pixart_alpha_lora.md
+++ b/docs/source/run_guides/run_pixart_alpha_lora.md
@@ -80,6 +80,6 @@ img.save("demo.png")
 
 #### pixart_alpha_1024_lora_pokemon_blip
 
-![example1](https://github.com/okotaku/diffengine/assets/24734142/1f884a73-e734-42fe-88f2-87d3ea22672d)
+![example1](https://github.com/okotaku/diffengine/assets/24734142/33f9c774-7896-4032-a11b-b86f4334de0a)
 
 You can check [`configs/pixart_alpha_lora/README.md`](../../../configs/pixart_alpha_lora/README.md#results-example) for more details.

--- a/docs/source/run_guides/run_pixart_alpha_lora.md
+++ b/docs/source/run_guides/run_pixart_alpha_lora.md
@@ -1,0 +1,85 @@
+# PixArt-α LoRA Training
+
+You can also check [`configs/pixart_alpha_lora/README.md`](../../../configs/pixart_alpha_lora/README.md) file.
+
+## Configs
+
+All configuration files are placed under the [`configs/pixart_alpha_lora`](../../../configs/pixart_alpha_lora/) folder.
+
+Following is the example config fixed from the pixart_alpha_1024_lora_pokemon_blip config file in [`configs/pixart_alpha_lora/pixart_alpha_1024_lora_pokemon_blip.py`](../../../configs/pixart_alpha_lora/pixart_alpha_1024_lora_pokemon_blip.py):
+
+```
+_base_ = [
+    "../_base_/models/pixart_alpha_1024_lora.py",
+    "../_base_/datasets/pokemon_blip_pixart.py",
+    "../_base_/schedules/stable_diffusion_50e.py",
+    "../_base_/default_runtime.py",
+]
+
+optim_wrapper = dict(
+    dtype="bfloat16")
+
+custom_hooks = [
+    dict(
+        type="VisualizationHook",
+        prompt=["yoda pokemon"] * 4,
+        height=1024,
+        width=1024),
+    dict(type="PeftSaveHook"),
+]
+```
+
+## Run LoRA training
+
+Run LoRA training:
+
+```
+# single gpu
+$ mim train diffengine ${CONFIG_FILE}
+# multi gpus
+$ mim train diffengine ${CONFIG_FILE} --gpus 2 --launcher pytorch
+
+# Example.
+$ mim train diffengine configs/pixart_alpha_lora/pixart_alpha_1024_lora_pokemon_blip.py
+```
+
+## Inference with diffusers
+
+Once you have trained a model, specify the path to the saved model and utilize it for inference using the `diffusers.pipeline` module.
+
+```py
+from pathlib import Path
+
+import torch
+from diffusers import PixArtAlphaPipeline, AutoencoderKL
+from peft import PeftModel
+
+checkpoint = Path('work_dirs/pixart_alpha_1024_lora_pokemon_blip/step20850')
+prompt = 'yoda pokemon'
+
+vae = AutoencoderKL.from_pretrained(
+    'stabilityai/sd-vae-ft-ema',
+)
+pipe = PixArtAlphaPipeline.from_pretrained(
+    "PixArt-alpha/PixArt-XL-2-1024-MS",
+    vae=vae,
+    torch_dtype=torch.float32,
+).to("cuda")
+pipe.transformer = PeftModel.from_pretrained(pipe.transformer, checkpoint / "transformer", adapter_name="default")
+
+img = pipe(
+    prompt,
+    width=1024,
+    height=1024,
+    num_inference_steps=50,
+).images[0]
+img.save("demo.png")
+```
+
+## Results Example
+
+#### pixart_alpha_1024_lora_pokemon_blip
+
+![example1](https://github.com/okotaku/diffengine/assets/24734142/1f884a73-e734-42fe-88f2-87d3ea22672d)
+
+You can check [`configs/pixart_alpha_lora/README.md`](../../../configs/pixart_alpha_lora/README.md#results-example) for more details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ dependencies = [
     "torchvision>=0.15.2",
     "openmim>=0.3.9",
     "datasets>=2.14.6",
-    "diffusers>=0.23.1",
+    "diffusers>=0.24.0",
     "mmengine>=0.10.1",
     "sentencepiece>=0.1.99",
     "tqdm",
-    "transformers>=4.34.1",
+    "transformers>=4.35.2",
     "ujson",
     "peft>=0.6.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ keywords = ["computer vision", "diffusion models"]
 
 [project.optional-dependencies]
 dev = ["pytest", "coverage"]
+optional = ["ftfy", "bs4"]
 docs = [
     "docutils==0.18.1",
     "modelindex",

--- a/tests/test_datasets/test_transforms/test_processing.py
+++ b/tests/test_datasets/test_transforms/test_processing.py
@@ -426,3 +426,43 @@ class TestRandomTextDrop(TestCase):
         trans = TRANSFORMS.build(dict(type="RandomTextDrop", p=0.))
         data = trans(data)
         assert data["text"] == "a dog"
+
+
+class TestComputePixArtImgInfo(TestCase):
+
+    def test_register(self):
+        assert "ComputePixArtImgInfo" in TRANSFORMS
+
+    def test_transform(self):
+        img_path = osp.join(osp.dirname(__file__), "../../testdata/color.jpg")
+        img = Image.open(img_path)
+        data = {"img": img, "ori_img_shape": [32, 32], "crop_top_left": [0, 0]}
+
+        # test transform
+        trans = TRANSFORMS.build(dict(type="ComputePixArtImgInfo"))
+        data = trans(data)
+        self.assertListEqual(data["resolution"],
+                             [float(d) for d in data["ori_img_shape"]])
+        assert data["aspect_ratio"] == img.height / img.width
+
+
+class TestT5TextPreprocess(TestCase):
+
+    def test_register(self):
+        assert "T5TextPreprocess" in TRANSFORMS
+
+    def test_transform(self):
+        data = {
+            "text": "A dog",
+        }
+
+        # test transform
+        trans = TRANSFORMS.build(dict(type="T5TextPreprocess"))
+        data = trans(data)
+        assert data["text"] == "a dog"
+
+        data = {
+            "text": "A dog in https://dummy.dummy",
+        }
+        data = trans(data)
+        assert data["text"] == "a dog in dummy. dummy"

--- a/tests/test_engine/test_hooks/test_compile_hook.py
+++ b/tests/test_engine/test_hooks/test_compile_hook.py
@@ -72,7 +72,7 @@ class TestCompileHook(RunnerTestCase):
         cfg.model.type = "StableDiffusion"
         cfg.model.model = "diffusers/tiny-stable-diffusion-torch"
         runner = self.build_runner(cfg)
-        hook = CompileHook(compile_unet=True)
+        hook = CompileHook(compile_main=True)
         assert isinstance(runner.model.unet, UNet2DConditionModel)
         assert isinstance(runner.model.vae, AutoencoderKL)
         assert isinstance(runner.model.text_encoder, CLIPTextModel)
@@ -88,7 +88,7 @@ class TestCompileHook(RunnerTestCase):
         cfg.model.model = "hf-internal-testing/tiny-stable-diffusion-pipe"
         cfg.model.controlnet_model="hf-internal-testing/tiny-controlnet"
         runner = self.build_runner(cfg)
-        hook = CompileHook(compile_unet=True)
+        hook = CompileHook(compile_main=True)
         func = runner.model._forward_compile
         assert runner.model._forward_compile == func
         assert isinstance(runner.model.vae, AutoencoderKL)
@@ -105,7 +105,7 @@ class TestCompileHook(RunnerTestCase):
         cfg.model.type = "StableDiffusionXL"
         cfg.model.model = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
         runner = self.build_runner(cfg)
-        hook = CompileHook(compile_unet=True)
+        hook = CompileHook(compile_main=True)
         assert isinstance(runner.model.unet, UNet2DConditionModel)
         assert isinstance(runner.model.vae, AutoencoderKL)
         assert isinstance(runner.model.text_encoder_one, CLIPTextModel)
@@ -125,7 +125,7 @@ class TestCompileHook(RunnerTestCase):
         cfg.model.model = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
         cfg.model.controlnet_model="hf-internal-testing/tiny-controlnet-sdxl"
         runner = self.build_runner(cfg)
-        hook = CompileHook(compile_unet=True)
+        hook = CompileHook(compile_main=True)
         func = runner.model._forward_compile
         assert runner.model._forward_compile == func
         assert isinstance(runner.model.vae, AutoencoderKL)
@@ -145,7 +145,7 @@ class TestCompileHook(RunnerTestCase):
         cfg.model.type = "StableDiffusionXLT2IAdapter"
         cfg.model.model = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
         runner = self.build_runner(cfg)
-        hook = CompileHook(compile_unet=True)
+        hook = CompileHook(compile_main=True)
         func = runner.model._forward_compile
         assert runner.model._forward_compile == func
         assert isinstance(runner.model.vae, AutoencoderKL)

--- a/tests/test_engine/test_hooks/test_fast_norm_hook.py
+++ b/tests/test_engine/test_hooks/test_fast_norm_hook.py
@@ -1,9 +1,12 @@
 import copy
 import unittest
 
+from diffusers import AutoencoderKL, Transformer2DModel
 from mmengine.registry import MODELS
 from mmengine.testing import RunnerTestCase
+from mmengine.testing.runner_test_case import ToyModel
 from torch import nn
+from transformers import T5EncoderModel
 
 from diffengine.engine.hooks import FastNormHook
 from diffengine.models.editors import (
@@ -21,6 +24,51 @@ try:
     import apex
 except ImportError:
     apex = None
+
+
+
+class ToyModelPixArt(ToyModel):
+
+    def __init__(self) -> None:
+        super().__init__()
+        height = 12
+        width = 12
+
+        model_kwargs = {
+            "attention_bias": True,
+            "cross_attention_dim": 32,
+            "attention_head_dim": height * width,
+            "num_attention_heads": 1,
+            "num_vector_embeds": 12,
+            "num_embeds_ada_norm": 12,
+            "norm_num_groups": 32,
+            "sample_size": width,
+            "activation_fn": "geglu-approximate",
+        }
+
+        self.transformer = Transformer2DModel(**model_kwargs)
+        self.text_encoder = T5EncoderModel.from_pretrained(
+            "hf-internal-testing/tiny-random-t5")
+        self.vae = AutoencoderKL(
+            in_channels=4,
+            out_channels=4,
+            down_block_types=("DownEncoderBlock2D",),
+            up_block_types=("UpDecoderBlock2D",),
+            block_out_channels=(32,),
+            layers_per_block=1,
+            act_fn="silu",
+            latent_channels=4,
+            norm_num_groups=16,
+            sample_size=16,
+        )
+        self.finetune_text_encoder = True
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    def forward(self, *args, **kwargs):
+        return super().forward(*args, **kwargs)
 
 
 class TestFastNormHook(RunnerTestCase):
@@ -42,6 +90,7 @@ class TestFastNormHook(RunnerTestCase):
         MODELS.register_module(name="L2Loss", module=L2Loss)
         MODELS.register_module(name="WhiteNoise", module=WhiteNoise)
         MODELS.register_module(name="TimeSteps", module=TimeSteps)
+        MODELS.register_module(name="ToyModelPixArt", module=ToyModelPixArt)
         return super().setUp()
 
     def tearDown(self) -> None:
@@ -54,6 +103,7 @@ class TestFastNormHook(RunnerTestCase):
         MODELS.module_dict.pop("L2Loss")
         MODELS.module_dict.pop("WhiteNoise")
         MODELS.module_dict.pop("TimeSteps")
+        MODELS.module_dict.pop("ToyModelPixArt")
         return super().tearDown()
 
     @unittest.skipIf(apex is None, "apex is not installed")
@@ -61,7 +111,7 @@ class TestFastNormHook(RunnerTestCase):
         FastNormHook()
 
     @unittest.skipIf(apex is None, "apex is not installed")
-    def test_before_train(self) -> None:
+    def test_before_train(self) -> None:  # noqa
         from apex.contrib.group_norm import GroupNorm
         from apex.normalization import FusedLayerNorm
 
@@ -163,3 +213,17 @@ class TestFastNormHook(RunnerTestCase):
         assert isinstance(
             runner.model.text_encoder_two.text_model.encoder.layers[
                 0].layer_norm1, FusedLayerNorm)
+
+        # test PixArt
+        cfg = copy.deepcopy(self.epoch_based_cfg)
+        cfg.model.type = "ToyModelPixArt"
+        runner = self.build_runner(cfg)
+        hook = FastNormHook(fuse_text_encoder_ln=True, fuse_gn=True)
+        assert isinstance(
+            runner.model.transformer.transformer_blocks[
+                0].norm1.norm, nn.LayerNorm)
+        # replace norm
+        hook.before_train(runner)
+        assert isinstance(
+            runner.model.transformer.transformer_blocks[
+                0].norm1.norm, FusedLayerNorm)

--- a/tests/test_engine/test_hooks/test_peft_save_hook.py
+++ b/tests/test_engine/test_hooks/test_peft_save_hook.py
@@ -187,6 +187,7 @@ class TestPeftSaveHook(RunnerTestCase):
 
         for key in checkpoint["state_dict"]:
             assert key.startswith(("unet", "text_encoder"))
+            assert "default" in key
 
     def test_before_save_checkpoint_text_encoder(self):
         # with text encoder
@@ -225,6 +226,7 @@ class TestPeftSaveHook(RunnerTestCase):
 
         for key in checkpoint["state_dict"]:
             assert key.startswith(("unet", "text_encoder"))
+            assert "default" in key
 
         # sdxl
         cfg = copy.deepcopy(self.epoch_based_cfg)
@@ -265,6 +267,7 @@ class TestPeftSaveHook(RunnerTestCase):
 
         for key in checkpoint["state_dict"]:
             assert key.startswith(("unet", "text_encoder"))
+            assert "default" in key
 
     def test_before_save_checkpoint_wuerstchen(self):
         # with text encoder
@@ -301,3 +304,4 @@ class TestPeftSaveHook(RunnerTestCase):
 
         for key in checkpoint["state_dict"]:
             assert key.startswith(("prior", "text_encoder"))
+            assert "default" in key

--- a/tests/test_engine/test_hooks/test_peft_save_hook.py
+++ b/tests/test_engine/test_hooks/test_peft_save_hook.py
@@ -181,7 +181,7 @@ class TestPeftSaveHook(RunnerTestCase):
 
         assert Path(
             osp.join(runner.work_dir, f"step{runner.iter}/unet",
-                     "adapter_model.bin")).exists()
+                     "adapter_model.safetensors")).exists()
         shutil.rmtree(
             osp.join(runner.work_dir, f"step{runner.iter}"))
 
@@ -217,10 +217,10 @@ class TestPeftSaveHook(RunnerTestCase):
 
         assert Path(
             osp.join(runner.work_dir, f"step{runner.iter}/unet",
-                     "adapter_model.bin")).exists()
+                     "adapter_model.safetensors")).exists()
         assert Path(
             osp.join(runner.work_dir, f"step{runner.iter}/text_encoder",
-                     "adapter_model.bin")).exists()
+                     "adapter_model.safetensors")).exists()
         shutil.rmtree(
             osp.join(runner.work_dir, f"step{runner.iter}"))
 
@@ -255,13 +255,13 @@ class TestPeftSaveHook(RunnerTestCase):
 
         assert Path(
             osp.join(runner.work_dir, f"step{runner.iter}/unet",
-                     "adapter_model.bin")).exists()
+                     "adapter_model.safetensors")).exists()
         assert Path(
             osp.join(runner.work_dir, f"step{runner.iter}/text_encoder_one",
-                     "adapter_model.bin")).exists()
+                     "adapter_model.safetensors")).exists()
         assert Path(
             osp.join(runner.work_dir, f"step{runner.iter}/text_encoder_two",
-                     "adapter_model.bin")).exists()
+                     "adapter_model.safetensors")).exists()
         shutil.rmtree(
             osp.join(runner.work_dir, f"step{runner.iter}"))
 
@@ -295,10 +295,10 @@ class TestPeftSaveHook(RunnerTestCase):
 
         assert Path(
             osp.join(runner.work_dir, f"step{runner.iter}/prior",
-                     "adapter_model.bin")).exists()
+                     "adapter_model.safetensors")).exists()
         assert Path(
             osp.join(runner.work_dir, f"step{runner.iter}/text_encoder",
-                     "adapter_model.bin")).exists()
+                     "adapter_model.safetensors")).exists()
         shutil.rmtree(
             osp.join(runner.work_dir, f"step{runner.iter}"))
 

--- a/tests/test_engine/test_hooks/test_pixart_checkpoint_hook.py
+++ b/tests/test_engine/test_hooks/test_pixart_checkpoint_hook.py
@@ -1,0 +1,60 @@
+import copy
+
+from mmengine.model import BaseModel
+from mmengine.registry import MODELS
+from mmengine.testing import RunnerTestCase
+from mmengine.testing.runner_test_case import ToyModel
+from torch import nn
+
+from diffengine.engine.hooks import PixArtCheckpointHook
+
+
+class DummyWrapper(BaseModel):
+
+    def __init__(self, model) -> None:
+        super().__init__()
+        if not isinstance(model, nn.Module):
+            model = MODELS.build(model)
+        self.module = model
+
+    def forward(self, *args, **kwargs):
+        return self.module(*args, **kwargs)
+
+
+class ToyModel2(ToyModel):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.transformer = nn.Linear(2, 1)
+        self.vae = nn.Linear(2, 1)
+        self.text_encoder = nn.Linear(2, 1)
+
+    def forward(self, *args, **kwargs):
+        return super().forward(*args, **kwargs)
+
+
+class TestPixArtCheckpointHook(RunnerTestCase):
+
+    def setUp(self) -> None:
+        MODELS.register_module(name="DummyWrapper", module=DummyWrapper)
+        MODELS.register_module(name="ToyModel2", module=ToyModel2)
+        return super().setUp()
+
+    def tearDown(self):
+        MODELS.module_dict.pop("DummyWrapper")
+        MODELS.module_dict.pop("ToyModel2")
+        return super().tearDown()
+
+    def test_init(self):
+        PixArtCheckpointHook()
+
+    def test_before_save_checkpoint(self):
+        cfg = copy.deepcopy(self.epoch_based_cfg)
+        cfg.model.type = "ToyModel2"
+        runner = self.build_runner(cfg)
+        checkpoint = dict(state_dict=ToyModel2().state_dict())
+        hook = PixArtCheckpointHook()
+        hook.before_save_checkpoint(runner, checkpoint)
+
+        for key in checkpoint["state_dict"]:
+            assert key.startswith(("transformer", "text_encoder"))

--- a/tests/test_engine/test_hooks/test_wuerstchen_save_hook.py
+++ b/tests/test_engine/test_hooks/test_wuerstchen_save_hook.py
@@ -58,7 +58,7 @@ class ToyModel2(ToyModel):
         return super().forward(*args, **kwargs)
 
 
-class TestSDCheckpointHook(RunnerTestCase):
+class TestWuerstchenSaveHook(RunnerTestCase):
 
     def setUp(self) -> None:
         MODELS.register_module(name="DummyWrapper", module=DummyWrapper)

--- a/tests/test_models/test_editors/test_pixart_alpha/test_pixart_alpha.py
+++ b/tests/test_models/test_editors/test_pixart_alpha/test_pixart_alpha.py
@@ -1,0 +1,262 @@
+from copy import deepcopy
+from unittest import TestCase
+
+import pytest
+import torch
+from diffusers import (
+    AutoencoderKL,
+    DDPMScheduler,
+    Transformer2DModel,
+)
+from mmengine import print_log
+from mmengine.optim import OptimWrapper
+from torch import nn
+from torch.optim import SGD
+from transformers import AutoTokenizer, T5EncoderModel
+
+from diffengine.models.editors import PixArtAlpha, PixArtAlphaDataPreprocessor
+from diffengine.models.losses import DeBiasEstimationLoss, L2Loss, SNRL2Loss
+from diffengine.registry import MODELS
+
+
+class DummyPixArtAlpha(PixArtAlpha):
+    def __init__(
+        self,
+        model: str = "PixArt-alpha/PixArt-XL-2-1024-MS",
+        loss: dict | None = None,
+        transformer_lora_config: dict | None = None,
+        text_encoder_lora_config: dict | None = None,
+        prior_loss_weight: float = 1.,
+        tokenizer_max_length: int = 120,
+        prediction_type: str | None = None,
+        data_preprocessor: dict | nn.Module | None = None,
+        noise_generator: dict | None = None,
+        timesteps_generator: dict | None = None,
+        input_perturbation_gamma: float = 0.0,
+        *,
+        finetune_text_encoder: bool = False,
+        gradient_checkpointing: bool = False,
+        enable_xformers: bool = False,
+    ) -> None:
+        if data_preprocessor is None:
+            data_preprocessor = {"type": "PixArtAlphaDataPreprocessor"}
+        if noise_generator is None:
+            noise_generator = {"type": "WhiteNoise"}
+        if timesteps_generator is None:
+            timesteps_generator = {"type": "TimeSteps"}
+        if loss is None:
+            loss = {"type": "L2Loss", "loss_weight": 1.0}
+        super(PixArtAlpha, self).__init__(data_preprocessor=data_preprocessor)
+        if (
+            transformer_lora_config is not None) and (
+                text_encoder_lora_config is not None) and (
+                    not finetune_text_encoder):
+                print_log(
+                    "You are using LoRA for Transformer and text encoder. "
+                    "But you are not set `finetune_text_encoder=True`. "
+                    "We will set `finetune_text_encoder=True` for you.")
+                finetune_text_encoder = True
+        if text_encoder_lora_config is not None:
+            assert finetune_text_encoder, (
+                "If you want to use LoRA for text encoder, "
+                "you should set finetune_text_encoder=True."
+            )
+        if finetune_text_encoder and transformer_lora_config is not None:
+            assert text_encoder_lora_config is not None, (
+                "If you want to finetune text encoder with LoRA Transformer, "
+                "you should set text_encoder_lora_config."
+            )
+
+        self.model = model
+        self.transformer_lora_config = deepcopy(transformer_lora_config)
+        self.text_encoder_lora_config = deepcopy(text_encoder_lora_config)
+        self.finetune_text_encoder = finetune_text_encoder
+        self.prior_loss_weight = prior_loss_weight
+        self.tokenizer_max_length = tokenizer_max_length
+        self.gradient_checkpointing = gradient_checkpointing
+        self.input_perturbation_gamma = input_perturbation_gamma
+        self.enable_xformers = enable_xformers
+
+        if not isinstance(loss, nn.Module):
+            loss = MODELS.build(loss)
+        self.loss_module: nn.Module = loss
+
+        assert prediction_type in [None, "epsilon", "v_prediction"]
+        self.prediction_type = prediction_type
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            "hf-internal-testing/tiny-random-t5")
+        self.scheduler = DDPMScheduler.from_pretrained(
+            model, subfolder="scheduler")
+
+        self.transformer = Transformer2DModel(
+            sample_size=8,
+            num_layers=2,
+            patch_size=2,
+            attention_head_dim=8,
+            num_attention_heads=3,
+            caption_channels=32,
+            in_channels=4,
+            cross_attention_dim=24,
+            out_channels=8,
+            attention_bias=True,
+            activation_fn="gelu-approximate",
+            num_embeds_ada_norm=1000,
+            norm_type="ada_norm_single",
+            norm_elementwise_affine=False,
+            norm_eps=1e-6,
+        )
+        self.text_encoder = T5EncoderModel.from_pretrained(
+            "hf-internal-testing/tiny-random-t5")
+        self.vae = AutoencoderKL()
+        self.noise_generator = MODELS.build(noise_generator)
+        self.timesteps_generator = MODELS.build(timesteps_generator)
+        self.prepare_model()
+        self.set_lora()
+        self.set_xformers()
+
+
+class TestPixArtAlpha(TestCase):
+
+    def test_init(self):
+        with pytest.raises(
+                AssertionError, match="If you want to use LoRA"):
+            _ = DummyPixArtAlpha(
+                text_encoder_lora_config=dict(type="dummy"),
+                data_preprocessor=PixArtAlphaDataPreprocessor())
+
+        with pytest.raises(
+                AssertionError, match="If you want to finetune text"):
+            _ = DummyPixArtAlpha(
+                transformer_lora_config=dict(type="dummy"),
+                finetune_text_encoder=True,
+                data_preprocessor=PixArtAlphaDataPreprocessor())
+
+    def test_train_step(self):
+        # test load with loss module
+        StableDiffuser = DummyPixArtAlpha(
+            loss=L2Loss(),
+            data_preprocessor=PixArtAlphaDataPreprocessor())
+
+        # test train step
+        data = dict(
+            inputs=dict(img=[torch.zeros((3, 64, 64))], text=["a dog"]))
+        optimizer = SGD(StableDiffuser.parameters(), lr=0.1)
+        optim_wrapper = OptimWrapper(optimizer)
+        log_vars = StableDiffuser.train_step(data, optim_wrapper)
+        assert log_vars
+        assert isinstance(log_vars["loss"], torch.Tensor)
+
+    def test_train_step_with_lora(self):
+        # test load with loss module
+        StableDiffuser = DummyPixArtAlpha(
+            loss=L2Loss(),
+            transformer_lora_config=dict(
+                type="LoRA", r=4,
+                target_modules=["to_q", "to_v", "to_k", "to_out.0"]),
+            text_encoder_lora_config = dict(
+                type="LoRA", r=4,
+                target_modules=["q", "k", "v", "o"]),
+            data_preprocessor=PixArtAlphaDataPreprocessor())
+
+        # test train step
+        data = dict(
+            inputs=dict(img=[torch.zeros((3, 64, 64))], text=["a dog"]))
+        optimizer = SGD(StableDiffuser.parameters(), lr=0.1)
+        optim_wrapper = OptimWrapper(optimizer)
+        log_vars = StableDiffuser.train_step(data, optim_wrapper)
+        assert log_vars
+        assert isinstance(log_vars["loss"], torch.Tensor)
+
+    def test_train_step_input_perturbation(self):
+        # test load with loss module
+        StableDiffuser = DummyPixArtAlpha(
+            input_perturbation_gamma=0.1,
+            loss=L2Loss(),
+            data_preprocessor=PixArtAlphaDataPreprocessor())
+
+        # test train step
+        data = dict(
+            inputs=dict(img=[torch.zeros((3, 64, 64))], text=["a dog"]))
+        optimizer = SGD(StableDiffuser.parameters(), lr=0.1)
+        optim_wrapper = OptimWrapper(optimizer)
+        log_vars = StableDiffuser.train_step(data, optim_wrapper)
+        assert log_vars
+        assert isinstance(log_vars["loss"], torch.Tensor)
+
+    def test_train_step_with_gradient_checkpointing(self):
+        # test load with loss module
+        StableDiffuser = DummyPixArtAlpha(
+            loss=L2Loss(),
+            data_preprocessor=PixArtAlphaDataPreprocessor(),
+            gradient_checkpointing=True)
+
+        # test train step
+        data = dict(
+            inputs=dict(img=[torch.zeros((3, 64, 64))], text=["a dog"]))
+        optimizer = SGD(StableDiffuser.parameters(), lr=0.1)
+        optim_wrapper = OptimWrapper(optimizer)
+        log_vars = StableDiffuser.train_step(data, optim_wrapper)
+        assert log_vars
+        assert isinstance(log_vars["loss"], torch.Tensor)
+
+    def test_train_step_dreambooth(self):
+        # test load with loss module
+        StableDiffuser = DummyPixArtAlpha(
+            loss=L2Loss(),
+            data_preprocessor=PixArtAlphaDataPreprocessor())
+
+        # test train step
+        data = dict(
+            inputs=dict(img=[torch.zeros((3, 64, 64))], text=["a sks dog"]))
+        data["inputs"]["result_class_image"] = dict(
+            img=[torch.zeros((3, 64, 64))],
+            text=["a dog"])  # type: ignore[assignment]
+        optimizer = SGD(StableDiffuser.parameters(), lr=0.1)
+        optim_wrapper = OptimWrapper(optimizer)
+        log_vars = StableDiffuser.train_step(data, optim_wrapper)
+        assert log_vars
+        assert isinstance(log_vars["loss"], torch.Tensor)
+
+    def test_train_step_snr_loss(self):
+        # test load with loss module
+        StableDiffuser = DummyPixArtAlpha(
+            loss=SNRL2Loss(),
+            data_preprocessor=PixArtAlphaDataPreprocessor())
+
+        # test train step
+        data = dict(
+            inputs=dict(img=[torch.zeros((3, 64, 64))], text=["a dog"]))
+        optimizer = SGD(StableDiffuser.parameters(), lr=0.1)
+        optim_wrapper = OptimWrapper(optimizer)
+        log_vars = StableDiffuser.train_step(data, optim_wrapper)
+        assert log_vars
+        assert isinstance(log_vars["loss"], torch.Tensor)
+
+    def test_train_step_debias_estimation_loss(self):
+        # test load with loss module
+        StableDiffuser = DummyPixArtAlpha(
+            loss=DeBiasEstimationLoss(),
+            data_preprocessor=PixArtAlphaDataPreprocessor())
+
+        # test train step
+        data = dict(
+            inputs=dict(img=[torch.zeros((3, 64, 64))], text=["a dog"]))
+        optimizer = SGD(StableDiffuser.parameters(), lr=0.1)
+        optim_wrapper = OptimWrapper(optimizer)
+        log_vars = StableDiffuser.train_step(data, optim_wrapper)
+        assert log_vars
+        assert isinstance(log_vars["loss"], torch.Tensor)
+
+    def test_val_and_test_step(self):
+        StableDiffuser = DummyPixArtAlpha(
+            loss=L2Loss(),
+            data_preprocessor=PixArtAlphaDataPreprocessor())
+
+        # test val_step
+        with pytest.raises(NotImplementedError, match="val_step is not"):
+            StableDiffuser.val_step(torch.zeros((1, )))
+
+        # test test_step
+        with pytest.raises(NotImplementedError, match="test_step is not"):
+            StableDiffuser.test_step(torch.zeros((1, )))

--- a/tools/model_converters/publish_model2diffusers.py
+++ b/tools/model_converters/publish_model2diffusers.py
@@ -18,7 +18,7 @@ def parse_args():  # noqa
         "--save-keys",
         nargs="+",
         type=str,
-        default=["unet", "text_encoder"],
+        default=["unet", "text_encoder", "transformer"],
         help="keys to save in the published checkpoint")
     return parser.parse_args()
 
@@ -34,7 +34,7 @@ def process_checkpoint(runner, out_dir, save_keys=None) -> None:
 
 def main() -> None:
     args = parse_args()
-    allowed_save_keys = ["unet", "text_encoder"]
+    allowed_save_keys = ["unet", "text_encoder", "transformer"]
     if not set(args.save_keys).issubset(set(allowed_save_keys)):
         msg = (f"These metrics are supported: {allowed_save_keys}, "
                f"but got {args.save_keys}")


### PR DESCRIPTION
## Motivation

[PixArt-α: Fast Training of Diffusion Transformer for Photorealistic Text-to-Image Synthesis](https://arxiv.org/abs/2310.00426)

## Results (Optional)

#### pixart_alpha_1024_pokemon_blip

![example1](https://github.com/okotaku/diffengine/assets/24734142/6b87369a-4746-4067-9a8a-5d7453fc80ce)

#### pixart_alpha_1024_lora_pokemon_blip

![example1](https://github.com/okotaku/diffengine/assets/24734142/33f9c774-7896-4032-a11b-b86f4334de0a)

#### pixart_alpha_512_dreambooth_lora_dog

![exampledog](https://github.com/okotaku/diffengine/assets/24734142/2d3b59b1-2a9b-422d-adba-347504c66be2)

#### pixart_alpha_1024_dreambooth_lora_dog

![exampledog2](https://github.com/okotaku/diffengine/assets/24734142/a3fc9fcd-7cd0-4dc2-997d-3a9b303c228a)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.


<!-- readthedocs-preview DiffEngine start -->
----
:books: Documentation preview :books:: https://DiffEngine--106.org.readthedocs.build/en/106/

<!-- readthedocs-preview DiffEngine end -->