### PR TITLE
[Feature] Support Finetune pretrained IP-Adapter

### DIFF
--- a/configs/ip_adapter/README.md
+++ b/configs/ip_adapter/README.md
@@ -89,3 +89,9 @@ You can see more details on [`docs/source/run_guides/run_ip_adapter.md`](../../d
 ![input1](https://datasets-server.huggingface.co/assets/lambdalabs/pokemon-blip-captions/--/default/train/0/image/image.jpg)
 
 ![example1](https://github.com/okotaku/diffengine/assets/24734142/723ad39d-9e0f-441b-80f7-cf9bcfd12853)
+
+#### stable_diffusion_xl_pokemon_blip_ip_adapter_plus_pretrained
+
+![input1](https://datasets-server.huggingface.co/assets/lambdalabs/pokemon-blip-captions/--/default/train/0/image/image.jpg)
+
+![example1](https://github.com/okotaku/diffengine/assets/24734142/ace81220-010b-44a5-aa8f-3acdf3f54433)

--- a/configs/ip_adapter/stable_diffusion_xl_pokemon_blip_ip_adapter_plus_pretrained.py
+++ b/configs/ip_adapter/stable_diffusion_xl_pokemon_blip_ip_adapter_plus_pretrained.py
@@ -1,0 +1,17 @@
+_base_ = [
+    "../_base_/models/stable_diffusion_xl_ip_adapter_plus.py",
+    "../_base_/datasets/pokemon_blip_xl_ip_adapter.py",
+    "../_base_/schedules/stable_diffusion_xl_50e.py",
+    "../_base_/default_runtime.py",
+]
+
+model = dict(image_encoder_sub_folder="models/image_encoder",
+             pretrained_adapter="h94/IP-Adapter",
+             pretrained_adapter_subfolder="sdxl_models",
+             pretrained_adapter_weights_name="ip-adapter-plus_sdxl_vit-h.bin")
+
+train_dataloader = dict(batch_size=1)
+
+optim_wrapper = dict(accumulative_counts=4)  # update every four times
+
+train_cfg = dict(by_epoch=True, max_epochs=10)

--- a/diffengine/models/archs/__init__.py
+++ b/diffengine/models/archs/__init__.py
@@ -1,9 +1,11 @@
 from .ip_adapter import (
+    load_ip_adapter,
+    process_ip_adapter_state_dict,
     set_unet_ip_adapter,
 )
 from .peft import create_peft_config
 
 __all__ = [
-    "set_unet_ip_adapter",
+    "set_unet_ip_adapter", "load_ip_adapter", "process_ip_adapter_state_dict",
     "create_peft_config",
 ]

--- a/diffengine/models/archs/ip_adapter.py
+++ b/diffengine/models/archs/ip_adapter.py
@@ -1,3 +1,6 @@
+from collections import OrderedDict
+
+import torch
 import torch.nn.functional as F  # noqa
 from diffusers.models.attention_processor import (
     AttnProcessor,
@@ -5,6 +8,9 @@ from diffusers.models.attention_processor import (
     IPAdapterAttnProcessor,
     IPAdapterAttnProcessor2_0,
 )
+from diffusers.models.embeddings import ImageProjection, Resampler
+from diffusers.utils import _get_model_file
+from safetensors import safe_open
 from torch import nn
 
 
@@ -47,3 +53,185 @@ def set_unet_ip_adapter(unet: nn.Module) -> None:
 
             key_id += 2
     unet.set_attn_processor(attn_procs)
+
+
+def load_ip_adapter(  # noqa: PLR0915, C901, PLR0912
+    unet: nn.Module,
+                    image_projection: nn.Module,
+                    pretrained_adapter: str,
+                    subfolder: str,
+                    weights_name: str) -> None:
+    """Load IP-Adapter pretrained weights.
+
+    Reference to diffusers/loaders/ip_adapter.py. and
+    diffusers/loaders/unet.py.
+    """
+    model_file = _get_model_file(
+        pretrained_adapter,
+        subfolder=subfolder,
+        weights_name=weights_name,
+        cache_dir=None,
+        force_download=False,
+        resume_download=False,
+        proxies=None,
+        local_files_only=None,
+        token=None,
+        revision=None,
+        user_agent={
+            "file_type": "attn_procs_weights",
+            "framework": "pytorch",
+        })
+    if weights_name.endswith(".safetensors"):
+        state_dict: dict = {"image_proj": {}, "ip_adapter": {}}
+        with safe_open(model_file, framework="pt", device="cpu") as f:
+            for key in f:
+                if key.startswith("image_proj."):
+                    state_dict["image_proj"][
+                        key.replace("image_proj.", "")] = f.get_tensor(key)
+                elif key.startswith("ip_adapter."):
+                    state_dict["ip_adapter"][
+                        key.replace("ip_adapter.", "")] = f.get_tensor(key)
+    else:
+        state_dict = torch.load(model_file, map_location="cpu")
+
+    key_id = 1
+    for name, attn_proc in unet.attn_processors.items():
+        cross_attention_dim = None if name.endswith(
+            "attn1.processor") else unet.config.cross_attention_dim
+        if cross_attention_dim is None or "motion_modules" in name:
+            continue
+        value_dict = {}
+        for k in attn_proc.state_dict():
+            value_dict.update({f"{k}": state_dict["ip_adapter"][f"{key_id}.{k}"]})
+
+        attn_proc.load_state_dict(value_dict)
+        key_id += 2
+
+    if "proj.weight" in state_dict["image_proj"]:
+        # IP-Adapter
+        image_proj_state_dict = {}
+        image_proj_state_dict.update(
+            {
+                "image_embeds.weight": state_dict["image_proj"]["proj.weight"],
+                "image_embeds.bias": state_dict["image_proj"]["proj.bias"],
+                "norm.weight": state_dict["image_proj"]["norm.weight"],
+                "norm.bias": state_dict["image_proj"]["norm.bias"],
+            },
+        )
+        image_projection.load_state_dict(image_proj_state_dict)
+        del image_proj_state_dict
+    elif "proj.3.weight" in state_dict["image_proj"]:
+        image_proj_state_dict = {}
+        image_proj_state_dict.update(
+            {
+                "ff.net.0.proj.weight": state_dict["image_proj"]["proj.0.weight"],
+                "ff.net.0.proj.bias": state_dict["image_proj"]["proj.0.bias"],
+                "ff.net.2.weight": state_dict["image_proj"]["proj.2.weight"],
+                "ff.net.2.bias": state_dict["image_proj"]["proj.2.bias"],
+                "norm.weight": state_dict["image_proj"]["proj.3.weight"],
+                "norm.bias": state_dict["image_proj"]["proj.3.bias"],
+            },
+        )
+        image_projection.load_state_dict(image_proj_state_dict)
+        del image_proj_state_dict
+    else:
+        # IP-Adapter Plus
+        new_sd = OrderedDict()
+        for k, v in state_dict["image_proj"].items():
+            if "0.to" in k:
+                new_k = k.replace("0.to", "2.to")
+            elif "1.0.weight" in k:
+                new_k = k.replace("1.0.weight", "3.0.weight")
+            elif "1.0.bias" in k:
+                new_k = k.replace("1.0.bias", "3.0.bias")
+            elif "1.1.weight" in k:
+                new_k = k.replace("1.1.weight", "3.1.net.0.proj.weight")
+            elif "1.3.weight" in k:
+                new_k = k.replace("1.3.weight", "3.1.net.2.weight")
+            else:
+                new_k = k
+
+            if "norm1" in new_k:
+                new_sd[new_k.replace("0.norm1", "0")] = v
+            elif "norm2" in new_k:
+                new_sd[new_k.replace("0.norm2", "1")] = v
+            elif "to_kv" in new_k:
+                v_chunk = v.chunk(2, dim=0)
+                new_sd[new_k.replace("to_kv", "to_k")] = v_chunk[0]
+                new_sd[new_k.replace("to_kv", "to_v")] = v_chunk[1]
+            elif "to_out" in new_k:
+                new_sd[new_k.replace("to_out", "to_out.0")] = v
+            else:
+                new_sd[new_k] = v
+        image_projection.load_state_dict(new_sd)
+    del state_dict
+    torch.cuda.empty_cache()
+
+
+def process_ip_adapter_state_dict(  # noqa: PLR0915, C901, PLR0912
+    unet: nn.Module, image_projection: nn.Module) -> dict:
+    """Process IP-Adapter state dict."""
+    adapter_modules = torch.nn.ModuleList([
+        v if isinstance(v, nn.Module) else nn.Identity(
+            ) for v in unet.attn_processors.values()])
+
+    # not save no grad key
+    ip_image_projection_state_dict = OrderedDict()
+    if isinstance(image_projection, ImageProjection):
+        for k, v in image_projection.state_dict().items():
+            new_k = k.replace("image_embeds.", "proj.")
+            ip_image_projection_state_dict[new_k] = v
+    elif isinstance(image_projection, Resampler):
+        for k, v in image_projection.state_dict().items():
+            if "2.to" in k:
+                new_k = k.replace("2.to", "0.to")
+            elif "layers.3.0.weight" in k:
+                new_k = k.replace("layers.3.0.weight", "layers.3.0.norm1.weight")
+            elif "layers.3.0.bias" in k:
+                new_k = k.replace("layers.3.0.bias", "layers.3.0.norm1.bias")
+            elif "layers.3.1.weight" in k:
+                new_k = k.replace("layers.3.1.weight", "layers.3.0.norm2.weight")
+            elif "layers.3.1.bias" in k:
+                new_k = k.replace("layers.3.1.bias", "layers.3.0.norm2.bias")
+            elif "3.0.weight" in k:
+                new_k = k.replace("3.0.weight", "1.0.weight")
+            elif "3.0.bias" in k:
+                new_k = k.replace("3.0.bias", "1.0.bias")
+            elif "3.0.weight" in k:
+                new_k = k.replace("3.0.weight", "1.0.weight")
+            elif "3.1.net.0.proj.weight" in k:
+                new_k = k.replace("3.1.net.0.proj.weight", "1.1.weight")
+            elif "3.1.net.2.weight" in k:
+                new_k = k.replace("3.1.net.2.weight", "1.3.weight")
+            elif "layers.0.0" in k:
+                new_k = k.replace("layers.0.0", "layers.0.0.norm1")
+            elif "layers.0.1" in k:
+                new_k = k.replace("layers.0.1", "layers.0.0.norm2")
+            elif "layers.1.0" in k:
+                new_k = k.replace("layers.1.0", "layers.1.0.norm1")
+            elif "layers.1.1" in k:
+                new_k = k.replace("layers.1.1", "layers.1.0.norm2")
+            elif "layers.2.0" in k:
+                new_k = k.replace("layers.2.0", "layers.2.0.norm1")
+            elif "layers.2.1" in k:
+                new_k = k.replace("layers.2.1", "layers.2.0.norm2")
+            else:
+                new_k = k
+
+            if "norm_cross" in new_k:
+                ip_image_projection_state_dict[new_k.replace("norm_cross", "norm1")] = v
+            elif "layer_norm" in new_k:
+                ip_image_projection_state_dict[new_k.replace("layer_norm", "norm2")] = v
+            elif "to_k" in new_k:
+                ip_image_projection_state_dict[
+                    new_k.replace("to_k", "to_kv")] = torch.cat([
+                    v, image_projection.state_dict()[k.replace("to_k", "to_v")]], dim=0)
+            elif "to_v" in new_k:
+                continue
+            elif "to_out.0" in new_k:
+                ip_image_projection_state_dict[new_k.replace("to_out.0", "to_out")] = v
+            else:
+                ip_image_projection_state_dict[new_k] = v
+
+    return {"image_proj": ip_image_projection_state_dict,
+            "ip_adapter": adapter_modules.state_dict()}

--- a/tests/test_engine/test_hooks/test_ip_adapter_save_hook.py
+++ b/tests/test_engine/test_hooks/test_ip_adapter_save_hook.py
@@ -56,11 +56,13 @@ class TestIPAdapterSaveHook(RunnerTestCase):
         cfg.model.type = "IPAdapterXL"
         cfg.model.model = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
         cfg.model.image_encoder = 'hf-internal-testing/unidiffuser-diffusers-test'  # noqa
+        cfg.model.image_encoder_sub_folder = "image_encoder"
         runner = self.build_runner(cfg)
         checkpoint = dict(
             state_dict=IPAdapterXL(
                 model="hf-internal-testing/tiny-stable-diffusion-xl-pipe",
                 image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+                image_encoder_sub_folder="image_encoder",
             ).state_dict())
         hook = IPAdapterSaveHook()
         hook.before_save_checkpoint(runner, checkpoint)

--- a/tests/test_models/test_archs.py
+++ b/tests/test_models/test_archs.py
@@ -2,10 +2,12 @@ from typing import Any
 
 import pytest
 from diffusers import UNet2DConditionModel
+from diffusers.models.embeddings import ImageProjection, Resampler
 from peft import LoHaConfig, LoKrConfig, LoraConfig, OFTConfig
 
 from diffengine.models.archs import (
     create_peft_config,
+    process_ip_adapter_state_dict,
     set_unet_ip_adapter,
 )
 
@@ -61,3 +63,33 @@ def test_create_peft_config():
     config = create_peft_config(config)
     assert isinstance(config, OFTConfig)
     assert config.r == 8
+
+
+def test_process_ip_adapter_state_dict():
+    unet = UNet2DConditionModel.from_pretrained(
+        "hf-internal-testing/tiny-stable-diffusion-xl-pipe", subfolder="unet")
+    set_unet_ip_adapter(unet)
+    proj = ImageProjection(
+        cross_attention_dim=128,
+        image_embed_dim=128,
+        num_image_text_embeds=4,
+    )
+    proj_state_dict = process_ip_adapter_state_dict(unet, proj)
+    assert list(proj_state_dict.keys()) == ["image_proj", "ip_adapter"]
+    assert "proj.weight" in proj_state_dict["image_proj"]
+    assert len(proj_state_dict["ip_adapter"]) == 24
+
+    resampler = Resampler(
+        embed_dims=32,
+        output_dims=32,
+        hidden_dims=128,
+        depth=1,
+        dim_head=2,
+        heads=2,
+        num_queries=4,
+        ffn_ratio=1,
+    )
+    proj_state_dict = process_ip_adapter_state_dict(unet, resampler)
+    assert list(proj_state_dict.keys()) == ["image_proj", "ip_adapter"]
+    assert "latents" in proj_state_dict["image_proj"]
+    assert len(proj_state_dict["ip_adapter"]) == 24

--- a/tests/test_models/test_editors/test_ip_adapter/test_ip_adapter.py
+++ b/tests/test_models/test_editors/test_ip_adapter/test_ip_adapter.py
@@ -1,12 +1,110 @@
 from unittest import TestCase
 
+import numpy as np
 import pytest
 import torch
+from diffusers import DiffusionPipeline
+from diffusers.utils import load_image
 from mmengine.optim import OptimWrapper
+from PIL import Image
 from torch.optim import SGD
+from transformers import CLIPImageProcessor
 
-from diffengine.models.editors import IPAdapterXL, IPAdapterXLDataPreprocessor
+from diffengine.models.archs import process_ip_adapter_state_dict
+from diffengine.models.editors import IPAdapterXL as Base
+from diffengine.models.editors import IPAdapterXLDataPreprocessor
 from diffengine.models.losses import L2Loss
+
+
+class IPAdapterXL(Base):
+    @torch.no_grad()
+    def infer(self,
+              prompt: list[str],
+              example_image: list[str | Image.Image],
+              negative_prompt: str | None = None,
+              height: int | None = None,
+              width: int | None = None,
+              num_inference_steps: int = 50,
+              output_type: str = "pil",
+              **kwargs) -> list[np.ndarray]:
+        """Inference function.
+
+        Args:
+        ----
+            prompt (`List[str]`):
+                The prompt or prompts to guide the image generation.
+            example_image (`List[Union[str, Image.Image]]`):
+                The image prompt or prompts to guide the image generation.
+            negative_prompt (`Optional[str]`):
+                The prompt or prompts to guide the image generation.
+                Defaults to None.
+            height (int, optional):
+                The height in pixels of the generated image. Defaults to None.
+            width (int, optional):
+                The width in pixels of the generated image. Defaults to None.
+            num_inference_steps (int): Number of inference steps.
+                Defaults to 50.
+            output_type (str): The output format of the generate image.
+                Choose between 'pil' and 'latent'. Defaults to 'pil'.
+            **kwargs: Other arguments.
+        """
+        assert len(prompt) == len(example_image)
+
+        orig_encoder_hid_proj = self.unet.encoder_hid_proj
+        orig_encoder_hid_dim_type = self.unet.config.encoder_hid_dim_type
+
+        pipeline = DiffusionPipeline.from_pretrained(
+            self.model,
+            vae=self.vae,
+            text_encoder=self.text_encoder_one,
+            text_encoder_2=self.text_encoder_two,
+            tokenizer=self.tokenizer_one,
+            tokenizer_2=self.tokenizer_two,
+            unet=self.unet,
+            image_encoder=self.image_encoder,
+            feature_extractor=CLIPImageProcessor.from_pretrained(
+                self.image_encoder_name, subfolder="image_processor"),
+            torch_dtype=(torch.float16 if self.device != torch.device("cpu")
+                         else torch.float32),
+        )
+        adapter_state_dict = process_ip_adapter_state_dict(
+            self.unet, self.image_projection)
+        pipeline.load_ip_adapter(
+            pretrained_model_name_or_path_or_dict=adapter_state_dict,
+            subfolder="", weight_name="")
+        if self.prediction_type is not None:
+            # set prediction_type of scheduler if defined
+            scheduler_args = {"prediction_type": self.prediction_type}
+            pipeline.scheduler = pipeline.scheduler.from_config(
+                pipeline.scheduler.config, **scheduler_args)
+        pipeline.to(self.device)
+        pipeline.set_progress_bar_config(disable=True)
+        images = []
+        for p, img in zip(prompt, example_image, strict=True):
+            pil_img = load_image(img) if isinstance(img, str) else img
+            pil_img = pil_img.convert("RGB")
+
+            image = pipeline(
+                p,
+                ip_adapter_image=pil_img,
+                negative_prompt=negative_prompt,
+                num_inference_steps=num_inference_steps,
+                height=height,
+                width=width,
+                output_type=output_type,
+                **kwargs).images[0]
+            if output_type == "latent":
+                images.append(image)
+            else:
+                images.append(np.array(image))
+
+        del pipeline, adapter_state_dict
+        torch.cuda.empty_cache()
+
+        self.unet.encoder_hid_proj = orig_encoder_hid_proj
+        self.unet.config.encoder_hid_dim_type = orig_encoder_hid_dim_type
+
+        return images
 
 
 class TestIPAdapterXL(TestCase):
@@ -17,6 +115,7 @@ class TestIPAdapterXL(TestCase):
             _ = IPAdapterXL(
                 "hf-internal-testing/tiny-stable-diffusion-pipe",
                 image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+                image_encoder_sub_folder="image_encoder",
                 data_preprocessor=IPAdapterXLDataPreprocessor(),
                 unet_lora_config=dict(type="dummy"))
 
@@ -25,6 +124,7 @@ class TestIPAdapterXL(TestCase):
             _ = IPAdapterXL(
                 "hf-internal-testing/tiny-stable-diffusion-pipe",
                 image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+                image_encoder_sub_folder="image_encoder",
                 data_preprocessor=IPAdapterXLDataPreprocessor(),
                 text_encoder_lora_config=dict(type="dummy"))
 
@@ -34,6 +134,7 @@ class TestIPAdapterXL(TestCase):
             _ = IPAdapterXL(
                 "hf-internal-testing/tiny-stable-diffusion-pipe",
                 image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+                image_encoder_sub_folder="image_encoder",
                 data_preprocessor=IPAdapterXLDataPreprocessor(),
                 finetune_text_encoder=True)
 
@@ -41,6 +142,7 @@ class TestIPAdapterXL(TestCase):
         StableDiffuser = IPAdapterXL(
             "hf-internal-testing/tiny-stable-diffusion-xl-pipe",
             image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+            image_encoder_sub_folder="image_encoder",
             data_preprocessor=IPAdapterXLDataPreprocessor())
 
         # test infer
@@ -81,6 +183,7 @@ class TestIPAdapterXL(TestCase):
         StableDiffuser = IPAdapterXL(
             "hf-internal-testing/tiny-stable-diffusion-xl-pipe",
             image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+            image_encoder_sub_folder="image_encoder",
             loss=L2Loss(),
             data_preprocessor=IPAdapterXLDataPreprocessor())
 
@@ -102,6 +205,7 @@ class TestIPAdapterXL(TestCase):
         StableDiffuser = IPAdapterXL(
             "hf-internal-testing/tiny-stable-diffusion-xl-pipe",
             image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+            image_encoder_sub_folder="image_encoder",
             loss=L2Loss(),
             data_preprocessor=IPAdapterXLDataPreprocessor(),
             gradient_checkpointing=True)
@@ -123,6 +227,7 @@ class TestIPAdapterXL(TestCase):
         StableDiffuser = IPAdapterXL(
             "hf-internal-testing/tiny-stable-diffusion-xl-pipe",
             image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+            image_encoder_sub_folder="image_encoder",
             loss=L2Loss(),
             data_preprocessor=IPAdapterXLDataPreprocessor())
 

--- a/tests/test_models/test_editors/test_ip_adapter/test_ip_adapter_plus.py
+++ b/tests/test_models/test_editors/test_ip_adapter/test_ip_adapter_plus.py
@@ -1,12 +1,110 @@
 from unittest import TestCase
 
+import numpy as np
 import pytest
 import torch
+from diffusers import DiffusionPipeline
+from diffusers.utils import load_image
 from mmengine.optim import OptimWrapper
+from PIL import Image
 from torch.optim import SGD
+from transformers import CLIPImageProcessor
 
-from diffengine.models.editors import IPAdapterXLDataPreprocessor, IPAdapterXLPlus
+from diffengine.models.archs import process_ip_adapter_state_dict
+from diffengine.models.editors import IPAdapterXLDataPreprocessor
+from diffengine.models.editors import IPAdapterXLPlus as Base
 from diffengine.models.losses import L2Loss
+
+
+class IPAdapterXLPlus(Base):
+    @torch.no_grad()
+    def infer(self,
+              prompt: list[str],
+              example_image: list[str | Image.Image],
+              negative_prompt: str | None = None,
+              height: int | None = None,
+              width: int | None = None,
+              num_inference_steps: int = 50,
+              output_type: str = "pil",
+              **kwargs) -> list[np.ndarray]:
+        """Inference function.
+
+        Args:
+        ----
+            prompt (`List[str]`):
+                The prompt or prompts to guide the image generation.
+            example_image (`List[Union[str, Image.Image]]`):
+                The image prompt or prompts to guide the image generation.
+            negative_prompt (`Optional[str]`):
+                The prompt or prompts to guide the image generation.
+                Defaults to None.
+            height (int, optional):
+                The height in pixels of the generated image. Defaults to None.
+            width (int, optional):
+                The width in pixels of the generated image. Defaults to None.
+            num_inference_steps (int): Number of inference steps.
+                Defaults to 50.
+            output_type (str): The output format of the generate image.
+                Choose between 'pil' and 'latent'. Defaults to 'pil'.
+            **kwargs: Other arguments.
+        """
+        assert len(prompt) == len(example_image)
+
+        orig_encoder_hid_proj = self.unet.encoder_hid_proj
+        orig_encoder_hid_dim_type = self.unet.config.encoder_hid_dim_type
+
+        pipeline = DiffusionPipeline.from_pretrained(
+            self.model,
+            vae=self.vae,
+            text_encoder=self.text_encoder_one,
+            text_encoder_2=self.text_encoder_two,
+            tokenizer=self.tokenizer_one,
+            tokenizer_2=self.tokenizer_two,
+            unet=self.unet,
+            image_encoder=self.image_encoder,
+            feature_extractor=CLIPImageProcessor.from_pretrained(
+                self.image_encoder_name, subfolder="image_processor"),
+            torch_dtype=(torch.float16 if self.device != torch.device("cpu")
+                         else torch.float32),
+        )
+        adapter_state_dict = process_ip_adapter_state_dict(
+            self.unet, self.image_projection)
+        pipeline.load_ip_adapter(
+            pretrained_model_name_or_path_or_dict=adapter_state_dict,
+            subfolder="", weight_name="")
+        if self.prediction_type is not None:
+            # set prediction_type of scheduler if defined
+            scheduler_args = {"prediction_type": self.prediction_type}
+            pipeline.scheduler = pipeline.scheduler.from_config(
+                pipeline.scheduler.config, **scheduler_args)
+        pipeline.to(self.device)
+        pipeline.set_progress_bar_config(disable=True)
+        images = []
+        for p, img in zip(prompt, example_image, strict=True):
+            pil_img = load_image(img) if isinstance(img, str) else img
+            pil_img = pil_img.convert("RGB")
+
+            image = pipeline(
+                p,
+                ip_adapter_image=pil_img,
+                negative_prompt=negative_prompt,
+                num_inference_steps=num_inference_steps,
+                height=height,
+                width=width,
+                output_type=output_type,
+                **kwargs).images[0]
+            if output_type == "latent":
+                images.append(image)
+            else:
+                images.append(np.array(image))
+
+        del pipeline, adapter_state_dict
+        torch.cuda.empty_cache()
+
+        self.unet.encoder_hid_proj = orig_encoder_hid_proj
+        self.unet.config.encoder_hid_dim_type = orig_encoder_hid_dim_type
+
+        return images
 
 
 class TestIPAdapterXL(TestCase):
@@ -17,6 +115,7 @@ class TestIPAdapterXL(TestCase):
             _ = IPAdapterXLPlus(
                 "hf-internal-testing/tiny-stable-diffusion-pipe",
                 image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+                image_encoder_sub_folder="image_encoder",
                 data_preprocessor=IPAdapterXLDataPreprocessor(),
                 unet_lora_config=dict(type="dummy"))
 
@@ -25,6 +124,7 @@ class TestIPAdapterXL(TestCase):
             _ = IPAdapterXLPlus(
                 "hf-internal-testing/tiny-stable-diffusion-pipe",
                 image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+                image_encoder_sub_folder="image_encoder",
                 data_preprocessor=IPAdapterXLDataPreprocessor(),
                 text_encoder_lora_config=dict(type="dummy"))
 
@@ -34,6 +134,7 @@ class TestIPAdapterXL(TestCase):
             _ = IPAdapterXLPlus(
                 "hf-internal-testing/tiny-stable-diffusion-pipe",
                 image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+                image_encoder_sub_folder="image_encoder",
                 data_preprocessor=IPAdapterXLDataPreprocessor(),
                 finetune_text_encoder=True)
 
@@ -41,6 +142,7 @@ class TestIPAdapterXL(TestCase):
         StableDiffuser = IPAdapterXLPlus(
             "hf-internal-testing/tiny-stable-diffusion-xl-pipe",
             image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+            image_encoder_sub_folder="image_encoder",
             data_preprocessor=IPAdapterXLDataPreprocessor())
 
         # test infer
@@ -81,6 +183,7 @@ class TestIPAdapterXL(TestCase):
         StableDiffuser = IPAdapterXLPlus(
             "hf-internal-testing/tiny-stable-diffusion-xl-pipe",
             image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+            image_encoder_sub_folder="image_encoder",
             loss=L2Loss(),
             data_preprocessor=IPAdapterXLDataPreprocessor())
 
@@ -102,6 +205,7 @@ class TestIPAdapterXL(TestCase):
         StableDiffuser = IPAdapterXLPlus(
             "hf-internal-testing/tiny-stable-diffusion-xl-pipe",
             image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+            image_encoder_sub_folder="image_encoder",
             loss=L2Loss(),
             data_preprocessor=IPAdapterXLDataPreprocessor(),
             gradient_checkpointing=True)
@@ -123,6 +227,7 @@ class TestIPAdapterXL(TestCase):
         StableDiffuser = IPAdapterXLPlus(
             "hf-internal-testing/tiny-stable-diffusion-xl-pipe",
             image_encoder="hf-internal-testing/unidiffuser-diffusers-test",
+            image_encoder_sub_folder="image_encoder",
             loss=L2Loss(),
             data_preprocessor=IPAdapterXLDataPreprocessor())
 


### PR DESCRIPTION
## Motivation

Finetune pretrained IP-Adapter

## Results (Optional)

#### stable_diffusion_xl_pokemon_blip_ip_adapter_plus_pretrained

![input1](https://datasets-server.huggingface.co/assets/lambdalabs/pokemon-blip-captions/--/default/train/0/image/image.jpg)

![example1](https://github.com/okotaku/diffengine/assets/24734142/ace81220-010b-44a5-aa8f-3acdf3f54433)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.


<!-- readthedocs-preview DiffEngine start -->
----
📚 Documentation preview 📚: https://DiffEngine--115.org.readthedocs.build/en/115/

<!-- readthedocs-preview DiffEngine end -->