### PR TITLE
[Feature] Support VAE batch

### DIFF
--- a/diffengine/models/editors/distill_sd/distill_sd_xl.py
+++ b/diffengine/models/editors/distill_sd/distill_sd_xl.py
@@ -188,8 +188,7 @@ class DistillSDXL(StableDiffusionXL):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents)
 

--- a/diffengine/models/editors/instruct_pix2pix/instruct_pix2pix_xl.py
+++ b/diffengine/models/editors/instruct_pix2pix/instruct_pix2pix_xl.py
@@ -196,8 +196,7 @@ class StableDiffusionXLInstructPix2Pix(StableDiffusionXL):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents)
 
@@ -230,7 +229,7 @@ class StableDiffusionXLInstructPix2Pix(StableDiffusionXL):
         }
 
         # condition
-        cond_latents = self.vae.encode(inputs["condition_img"]).latent_dist.sample()
+        cond_latents = self._forward_vae(inputs["condition_img"], num_batches)
         # random zeros cond latents
         mask = torch.multinomial(
             torch.Tensor([

--- a/diffengine/models/editors/ip_adapter/ip_adapter_xl.py
+++ b/diffengine/models/editors/ip_adapter/ip_adapter_xl.py
@@ -258,8 +258,7 @@ class IPAdapterXL(StableDiffusionXL):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents)
 
@@ -358,8 +357,7 @@ class IPAdapterXLPlus(IPAdapterXL):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents)
 

--- a/diffengine/models/editors/lcm/lcm_xl.py
+++ b/diffengine/models/editors/lcm/lcm_xl.py
@@ -253,8 +253,7 @@ class LatentConsistencyModelsXL(StableDiffusionXL):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents)
 

--- a/diffengine/models/editors/pixart_alpha/pixart_alpha.py
+++ b/diffengine/models/editors/pixart_alpha/pixart_alpha.py
@@ -56,6 +56,7 @@ class PixArtAlpha(BaseModel):
         input_perturbation_gamma (float): The gamma of input perturbation.
             The recommended value is 0.1 for Input Perturbation.
             Defaults to 0.0.
+        vae_batch_size (int): The batch size of vae. Defaults to 8.
         finetune_text_encoder (bool, optional): Whether to fine-tune text
             encoder. Defaults to False.
         gradient_checkpointing (bool): Whether or not to use gradient
@@ -83,6 +84,7 @@ class PixArtAlpha(BaseModel):
         noise_generator: dict | None = None,
         timesteps_generator: dict | None = None,
         input_perturbation_gamma: float = 0.0,
+        vae_batch_size: int = 8,
         *,
         finetune_text_encoder: bool = False,
         gradient_checkpointing: bool = False,
@@ -126,6 +128,7 @@ class PixArtAlpha(BaseModel):
         self.gradient_checkpointing = gradient_checkpointing
         self.input_perturbation_gamma = input_perturbation_gamma
         self.enable_xformers = enable_xformers
+        self.vae_batch_size = vae_batch_size
 
         if not isinstance(loss, nn.Module):
             loss = MODELS.build(
@@ -353,6 +356,18 @@ class PixArtAlpha(BaseModel):
             input_noise = noise
         return self.scheduler.add_noise(latents, input_noise, timesteps)
 
+    def _forward_vae(self, img: torch.Tensor, num_batches: int,
+                     ) -> torch.Tensor:
+        """Forward vae."""
+        latents = [
+            self.vae.encode(
+                img[i : i + self.vae_batch_size],
+            ).latent_dist.sample() for i in range(
+                0, num_batches, self.vae_batch_size)
+        ]
+        latents = torch.cat(latents, dim=0)
+        return latents * self.vae.config.scaling_factor
+
     def forward(
             self,
             inputs: dict,
@@ -390,8 +405,7 @@ class PixArtAlpha(BaseModel):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents)
 

--- a/diffengine/models/editors/ssd_1b/ssd_1b.py
+++ b/diffengine/models/editors/ssd_1b/ssd_1b.py
@@ -59,6 +59,7 @@ class SSD1B(StableDiffusionXL):
         input_perturbation_gamma (float): The gamma of input perturbation.
             The recommended value is 0.1 for Input Perturbation.
             Defaults to 0.0.
+        vae_batch_size (int): The batch size of vae. Defaults to 8.
         finetune_text_encoder (bool, optional): Whether to fine-tune text
             encoder. Defaults to False.
         gradient_checkpointing (bool): Whether or not to use gradient
@@ -92,6 +93,7 @@ class SSD1B(StableDiffusionXL):
         noise_generator: dict | None = None,
         timesteps_generator: dict | None = None,
         input_perturbation_gamma: float = 0.0,
+        vae_batch_size: int = 8,
         *,
         finetune_text_encoder: bool = False,
         gradient_checkpointing: bool = False,
@@ -122,6 +124,7 @@ class SSD1B(StableDiffusionXL):
         self.pre_compute_text_embeddings = pre_compute_text_embeddings
         self.input_perturbation_gamma = input_perturbation_gamma
         self.enable_xformers = enable_xformers
+        self.vae_batch_size = vae_batch_size
 
         if not isinstance(loss, nn.Module):
             loss = MODELS.build(
@@ -264,6 +267,18 @@ class SSD1B(StableDiffusionXL):
                     msg,
                 )
 
+    def _forward_vae(self, img: torch.Tensor, num_batches: int,
+                     ) -> torch.Tensor:
+        """Forward vae."""
+        latents = [
+            self.vae.encode(
+                img[i : i + self.vae_batch_size],
+            ).latent_dist.sample() for i in range(
+                0, num_batches, self.vae_batch_size)
+        ]
+        latents = torch.cat(latents, dim=0)
+        return latents * self.vae.config.scaling_factor
+
     def forward(
             self,
             inputs: dict,
@@ -293,8 +308,7 @@ class SSD1B(StableDiffusionXL):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents)
 

--- a/diffengine/models/editors/stable_diffusion_controlnet/stable_diffusion_controlnet.py
+++ b/diffengine/models/editors/stable_diffusion_controlnet/stable_diffusion_controlnet.py
@@ -253,8 +253,7 @@ class StableDiffusionControlNet(StableDiffusion):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents)
 

--- a/diffengine/models/editors/stable_diffusion_inpaint/stable_diffusion_inpaint.py
+++ b/diffengine/models/editors/stable_diffusion_inpaint/stable_diffusion_inpaint.py
@@ -182,11 +182,8 @@ class StableDiffusionInpaint(StableDiffusion):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
-
-        masked_latents = self.vae.encode(inputs["masked_image"]).latent_dist.sample()
-        masked_latents = masked_latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
+        masked_latents = self._forward_vae(inputs["imasked_imagemg"], num_batches)
 
         mask = F.interpolate(inputs["mask"],
                              size=(latents.shape[2], latents.shape[3]))

--- a/diffengine/models/editors/stable_diffusion_inpaint/stable_diffusion_inpaint.py
+++ b/diffengine/models/editors/stable_diffusion_inpaint/stable_diffusion_inpaint.py
@@ -183,7 +183,7 @@ class StableDiffusionInpaint(StableDiffusion):
             weight = None
 
         latents = self._forward_vae(inputs["img"], num_batches)
-        masked_latents = self._forward_vae(inputs["imasked_imagemg"], num_batches)
+        masked_latents = self._forward_vae(inputs["masked_image"], num_batches)
 
         mask = F.interpolate(inputs["mask"],
                              size=(latents.shape[2], latents.shape[3]))

--- a/diffengine/models/editors/stable_diffusion_xl/stable_diffusion_xl.py
+++ b/diffengine/models/editors/stable_diffusion_xl/stable_diffusion_xl.py
@@ -58,6 +58,7 @@ class StableDiffusionXL(BaseModel):
         input_perturbation_gamma (float): The gamma of input perturbation.
             The recommended value is 0.1 for Input Perturbation.
             Defaults to 0.0.
+        vae_batch_size (int): The batch size of vae. Defaults to 8.
         finetune_text_encoder (bool, optional): Whether to fine-tune text
             encoder. Defaults to False.
         gradient_checkpointing (bool): Whether or not to use gradient
@@ -88,6 +89,7 @@ class StableDiffusionXL(BaseModel):
         noise_generator: dict | None = None,
         timesteps_generator: dict | None = None,
         input_perturbation_gamma: float = 0.0,
+        vae_batch_size: int = 8,
         *,
         finetune_text_encoder: bool = False,
         gradient_checkpointing: bool = False,
@@ -135,6 +137,7 @@ class StableDiffusionXL(BaseModel):
         self.pre_compute_text_embeddings = pre_compute_text_embeddings
         self.input_perturbation_gamma = input_perturbation_gamma
         self.enable_xformers = enable_xformers
+        self.vae_batch_size = vae_batch_size
 
         if not isinstance(loss, nn.Module):
             loss = MODELS.build(
@@ -419,6 +422,18 @@ class StableDiffusionXL(BaseModel):
             input_noise = noise
         return self.scheduler.add_noise(latents, input_noise, timesteps)
 
+    def _forward_vae(self, img: torch.Tensor, num_batches: int,
+                     ) -> torch.Tensor:
+        """Forward vae."""
+        latents = [
+            self.vae.encode(
+                img[i : i + self.vae_batch_size],
+            ).latent_dist.sample() for i in range(
+                0, num_batches, self.vae_batch_size)
+        ]
+        latents = torch.cat(latents, dim=0)
+        return latents * self.vae.config.scaling_factor
+
     def forward(
             self,
             inputs: dict,
@@ -448,8 +463,7 @@ class StableDiffusionXL(BaseModel):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents)
 

--- a/diffengine/models/editors/stable_diffusion_xl_controlnet/stable_diffusion_xl_controlnet.py
+++ b/diffengine/models/editors/stable_diffusion_xl_controlnet/stable_diffusion_xl_controlnet.py
@@ -266,8 +266,7 @@ class StableDiffusionXLControlNet(StableDiffusionXL):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents)
 

--- a/diffengine/models/editors/stable_diffusion_xl_dpo/stable_diffusion_xl_dpo.py
+++ b/diffengine/models/editors/stable_diffusion_xl_dpo/stable_diffusion_xl_dpo.py
@@ -135,8 +135,7 @@ class StableDiffusionXLDPO(StableDiffusionXL):
         # num_batches is divided by 2 because we have two images per sample
         num_batches = len(inputs["img"]) // 2
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents[:num_batches])
         # repeat noise for each sample set

--- a/diffengine/models/editors/stable_diffusion_xl_inpaint/stable_diffusion_xl_inpaint.py
+++ b/diffengine/models/editors/stable_diffusion_xl_inpaint/stable_diffusion_xl_inpaint.py
@@ -195,11 +195,8 @@ class StableDiffusionXLInpaint(StableDiffusionXL):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
-
-        masked_latents = self.vae.encode(inputs["masked_image"]).latent_dist.sample()
-        masked_latents = masked_latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
+        masked_latents = self._forward_vae(inputs["masked_image"], num_batches)
 
         mask = F.interpolate(inputs["mask"],
                              size=(latents.shape[2], latents.shape[3]))

--- a/diffengine/models/editors/t2i_adapter/stable_diffusion_xl_t2i_adapter.py
+++ b/diffengine/models/editors/t2i_adapter/stable_diffusion_xl_t2i_adapter.py
@@ -235,8 +235,7 @@ class StableDiffusionXLT2IAdapter(StableDiffusionXL):
         else:
             weight = None
 
-        latents = self.vae.encode(inputs["img"]).latent_dist.sample()
-        latents = latents * self.vae.config.scaling_factor
+        latents = self._forward_vae(inputs["img"], num_batches)
 
         noise = self.noise_generator(latents)
 


### PR DESCRIPTION
## Motivation

VAEs have high memory requirements, especially when processing large batches of data. To reduce the memory usage, we can use a VAE batch forward technique.
Based on https://github.com/huggingface/diffusers/blob/v0.26.2/examples/research_projects/controlnet/train_controlnet_webdataset.py#L1306-L1309 

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.


<!-- readthedocs-preview DiffEngine start -->
----
📚 Documentation preview 📚: https://DiffEngine--132.org.readthedocs.build/en/132/

<!-- readthedocs-preview DiffEngine end -->