### PR TITLE
[Featu] Support IP-Adapter Last hidden

### DIFF
--- a/diffengine/configs/ip_adapter/README.md
+++ b/diffengine/configs/ip_adapter/README.md
@@ -107,3 +107,9 @@ You can see more details on [`docs/source/run_guides/run_ip_adapter.md`](../../d
 ![input1](https://github.com/LambdaLabsML/examples/blob/main/stable-diffusion-finetuning/README_files/README_2_0.png?raw=true)
 
 ![example1](https://github.com/okotaku/diffengine/assets/24734142/f76c33ba-c1ac-4f6f-b256-d48de5e58bf8)
+
+#### stable_diffusion_xl_pokemon_blip_ip_adapter_plus_dinov2_giant_lasthidden
+
+![input1](https://github.com/LambdaLabsML/examples/blob/main/stable-diffusion-finetuning/README_files/README_2_0.png?raw=true)
+
+![example1](https://github.com/okotaku/diffengine/assets/24734142/4b37ce6c-60fd-4456-a542-74163927ee01)

--- a/diffengine/configs/ip_adapter/stable_diffusion_xl_pokemon_blip_ip_adapter_plus_dinov2_giant_lasthidden.py
+++ b/diffengine/configs/ip_adapter/stable_diffusion_xl_pokemon_blip_ip_adapter_plus_dinov2_giant_lasthidden.py
@@ -1,0 +1,23 @@
+from mmengine.config import read_base
+from transformers import AutoImageProcessor, Dinov2Model
+
+with read_base():
+    from .._base_.datasets.pokemon_blip_xl_ip_adapter_dinov2_giant import *
+    from .._base_.default_runtime import *
+    from .._base_.models.stable_diffusion_xl_ip_adapter_plus import *
+    from .._base_.schedules.stable_diffusion_xl_50e import *
+
+
+model.image_encoder = dict(
+    type=Dinov2Model.from_pretrained,
+    pretrained_model_name_or_path="facebook/dinov2-giant")
+model.feature_extractor = dict(
+    type=AutoImageProcessor.from_pretrained,
+    pretrained_model_name_or_path="facebook/dinov2-giant")
+model.update(dict(hidden_states_idx=-1))
+
+train_dataloader.update(batch_size=1)
+
+optim_wrapper.update(accumulative_counts=4)  # update every four times
+
+train_cfg.update(by_epoch=True, max_epochs=100)

--- a/diffengine/models/editors/ip_adapter/pipeline.py
+++ b/diffengine/models/editors/ip_adapter/pipeline.py
@@ -1,0 +1,89 @@
+# flake8: noqa
+import torch
+from diffusers import StableDiffusionXLPipeline
+
+
+class StableDiffusionXLPipelineCustomIPAdapter(StableDiffusionXLPipeline):
+    """Custom IP Adapter for the StableDiffusionXLPipeline class.
+
+    The difference between this class and the original
+    StableDiffusionXLPipeline class is that this class uses the hidden states
+    from the `hidden_states_idx` layer of the image encoder to encode the
+    image.
+
+    Args:
+        *args: Variable length argument list.
+        hidden_states_idx (int): Index of the hidden states to be used.
+            Defaults to -2.
+        **kwargs: Arbitrary keyword arguments.
+    """
+
+    def __init__(self,
+                vae,
+                text_encoder,
+                text_encoder_2,
+                tokenizer,
+                tokenizer_2,
+                unet,
+                scheduler,
+                image_encoder=None,
+                feature_extractor=None,
+                force_zeros_for_empty_prompt=True,
+                add_watermarker=None,
+                hidden_states_idx: int = -2):
+        super().__init__(vae=vae,
+            text_encoder=text_encoder,
+            text_encoder_2=text_encoder_2,
+            tokenizer=tokenizer,
+            tokenizer_2=tokenizer_2,
+            unet=unet,
+            scheduler=scheduler,
+            image_encoder=image_encoder,
+            feature_extractor=feature_extractor,
+            force_zeros_for_empty_prompt=force_zeros_for_empty_prompt,
+            add_watermarker=add_watermarker)
+        self.hidden_states_idx = hidden_states_idx
+
+    def encode_image(self, image, device, num_images_per_prompt, output_hidden_states=None):
+        """Encodes the image.
+
+        Args:
+            image: The input image to be encoded.
+            device: The device to be used for encoding.
+            num_images_per_prompt: The number of images per prompt.
+            output_hidden_states: Whether to output hidden states. Defaults to None.
+
+        Returns:
+            image_enc_hidden_states: Encoded hidden states of the image.
+            uncond_image_enc_hidden_states: Encoded hidden states of the unconditional image.
+        """
+        dtype = next(self.image_encoder.parameters()).dtype
+
+        if not isinstance(image, torch.Tensor):
+            image = self.feature_extractor(image, return_tensors="pt").pixel_values
+
+        image = image.to(device=device, dtype=dtype)
+        if output_hidden_states:
+            if self.hidden_states_idx == -1:
+                image_enc_hidden_states = self.image_encoder(image, output_hidden_states=True).last_hidden_state
+            else:
+                image_enc_hidden_states = self.image_encoder(image, output_hidden_states=True).hidden_states[self.hidden_states_idx]
+            image_enc_hidden_states = image_enc_hidden_states.repeat_interleave(num_images_per_prompt, dim=0)
+            if self.hidden_states_idx == -1:
+                uncond_image_enc_hidden_states = self.image_encoder(
+                    torch.zeros_like(image), output_hidden_states=True
+                ).last_hidden_state
+            else:
+                uncond_image_enc_hidden_states = self.image_encoder(
+                    torch.zeros_like(image), output_hidden_states=True
+                ).hidden_states[self.hidden_states_idx]
+            uncond_image_enc_hidden_states = uncond_image_enc_hidden_states.repeat_interleave(
+                num_images_per_prompt, dim=0,
+            )
+            return image_enc_hidden_states, uncond_image_enc_hidden_states
+        else:
+            image_embeds = self.image_encoder(image).image_embeds
+            image_embeds = image_embeds.repeat_interleave(num_images_per_prompt, dim=0)
+            uncond_image_embeds = torch.zeros_like(image_embeds)
+
+            return image_embeds, uncond_image_embeds


### PR DESCRIPTION
## Motivation

CLIP Image encoder skips last hidden layer. But DINOv2 can use it.

## Results (Optional)

#### stable_diffusion_xl_pokemon_blip_ip_adapter_plus_dinov2_giant_lasthidden

![input1](https://github.com/LambdaLabsML/examples/blob/main/stable-diffusion-finetuning/README_files/README_2_0.png?raw=true)

![example1](https://github.com/okotaku/diffengine/assets/24734142/4b37ce6c-60fd-4456-a542-74163927ee01)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.


<!-- readthedocs-preview DiffEngine start -->
----
📚 Documentation preview 📚: https://DiffEngine--134.org.readthedocs.build/en/134/

<!-- readthedocs-preview DiffEngine end -->