### PR TITLE
[Feat] Support IP-Adapter SigLIP

### DIFF
--- a/diffengine/configs/_base_/datasets/pokemon_blip_kandinsky_prior.py
+++ b/diffengine/configs/_base_/datasets/pokemon_blip_kandinsky_prior.py
@@ -6,7 +6,8 @@ from diffengine.engine.hooks import PriorSaveHook, VisualizationHook
 
 train_pipeline = [
     dict(type=CLIPImageProcessor, output_key="img",
-         pretrained="kandinsky-community/kandinsky-2-2-prior"),
+         pretrained="kandinsky-community/kandinsky-2-2-prior",
+         subfolder="image_processor"),
     dict(type=PackInputs),
 ]
 train_dataloader = dict(

--- a/diffengine/configs/ip_adapter/README.md
+++ b/diffengine/configs/ip_adapter/README.md
@@ -113,3 +113,9 @@ You can see more details on [`docs/source/run_guides/run_ip_adapter.md`](../../d
 ![input1](https://github.com/LambdaLabsML/examples/blob/main/stable-diffusion-finetuning/README_files/README_2_0.png?raw=true)
 
 ![example1](https://github.com/okotaku/diffengine/assets/24734142/4b37ce6c-60fd-4456-a542-74163927ee01)
+
+#### stable_diffusion_xl_pokemon_blip_ip_adapter_plus_siglip
+
+![input1](https://github.com/LambdaLabsML/examples/blob/main/stable-diffusion-finetuning/README_files/README_2_0.png?raw=true)
+
+![example1](https://github.com/okotaku/diffengine/assets/24734142/61e9279e-bd50-42b7-8a6f-1156a70466ea)

--- a/diffengine/configs/ip_adapter/stable_diffusion_xl_pokemon_blip_ip_adapter_plus_siglip.py
+++ b/diffengine/configs/ip_adapter/stable_diffusion_xl_pokemon_blip_ip_adapter_plus_siglip.py
@@ -1,0 +1,22 @@
+from mmengine.config import read_base
+from transformers import AutoImageProcessor, SiglipVisionModel
+
+with read_base():
+    from .._base_.datasets.pokemon_blip_xl_ip_adapter_siglip_384 import *
+    from .._base_.default_runtime import *
+    from .._base_.models.stable_diffusion_xl_ip_adapter_plus import *
+    from .._base_.schedules.stable_diffusion_xl_50e import *
+
+
+model.image_encoder = dict(
+    type=SiglipVisionModel.from_pretrained,
+    pretrained_model_name_or_path="google/siglip-so400m-patch14-384")
+model.feature_extractor = dict(
+    type=AutoImageProcessor.from_pretrained,
+    pretrained_model_name_or_path="google/siglip-so400m-patch14-384")
+
+train_dataloader.update(batch_size=1)
+
+optim_wrapper.update(accumulative_counts=4)  # update every four times
+
+train_cfg.update(by_epoch=True, max_epochs=100)

--- a/diffengine/datasets/transforms/processing.py
+++ b/diffengine/datasets/transforms/processing.py
@@ -543,15 +543,17 @@ class CLIPImageProcessor(BaseTransform):
             results. Defaults to 'clip_img'.
     """
 
-    def __init__(self, key: str = "img", output_key: str = "clip_img",
-                 pretrained: str | None = None) -> None:
+    def __init__(self, key: str = "img",
+                 output_key: str = "clip_img",
+                 pretrained: str | None = None,
+                 subfolder: str | None = None) -> None:
         self.key = key
         self.output_key = output_key
         if pretrained is None:
             self.pipeline = HFCLIPImageProcessor()
         else:
             self.pipeline = HFCLIPImageProcessor.from_pretrained(
-                pretrained, subfolder="image_processor")
+                pretrained, subfolder=subfolder)
 
     def transform(self, results: dict) -> dict | tuple[list, list] | None:
         """Transform.


### PR DESCRIPTION
## Motivation

The [IP-Adapter](https://arxiv.org/abs/2308.06721) support the [SigLIP](https://arxiv.org/abs/2303.15343) Image encoder.

## Results (Optional)

#### stable_diffusion_xl_pokemon_blip_ip_adapter_plus_siglip

![input1](https://github.com/LambdaLabsML/examples/blob/main/stable-diffusion-finetuning/README_files/README_2_0.png?raw=true)

![example1](https://github.com/okotaku/diffengine/assets/24734142/61e9279e-bd50-42b7-8a6f-1156a70466ea)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.


<!-- readthedocs-preview DiffEngine start -->
----
📚 Documentation preview 📚: https://DiffEngine--135.org.readthedocs.build/en/135/

<!-- readthedocs-preview DiffEngine end -->